### PR TITLE
Remove reaction bug fix

### DIFF
--- a/packages/messenger-widget/src/components/Message/Message.tsx
+++ b/packages/messenger-widget/src/components/Message/Message.tsx
@@ -39,6 +39,15 @@ export function Message(props: MessageProps) {
     };
 
     const deleteEmoji = async (deleteEmojiData: Envelop) => {
+        /**
+         * User can't remove reactions on his own messages.
+         * As the other account can only react to my messages.
+         * And only that other account can remove those reactions.
+         **/
+        if (props.ownMessage) {
+            return;
+        }
+
         if (!selectedContact) {
             throw Error('no contact selected');
         }


### PR DESCRIPTION
Fixed a bug of emoji reaction : Currently on click of emoji reaction on messages, the emoji was deleted. It lacks the check that only the account that has added the reaction could only remove it. This is fixed.