### PR TITLE
Feature/redefine authentication

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -160,6 +160,19 @@ jobs:
               with:
                   workspace-name: '@dm3-org/dm3-lib-storage'
                   package-pat: ${{ secrets.PACKAGE_PAT }}
+    lib-server-side-test:
+        runs-on: ubuntu-latest
+        needs: build
+        defaults:
+            run:
+                working-directory: 'packages/lib'
+        steps:
+            - uses: actions/checkout@v1
+            - id: workspace-test
+              uses: ./test-action
+              with:
+                  workspace-name: '@dm3-org/dm3-lib-server-side'
+                  package-pat: ${{ secrets.PACKAGE_PAT }}
     offchain-resolver-test:
         runs-on: ubuntu-latest
         needs: build

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,7 +28,7 @@
     "start": "yarn prisma-init && node  ./dist/index.js",
     "start-inspect": "node --inspect=0.0.0.0:9229  ./dist/index.js",
     "test": "yarn run before:tests && DATABASE_URL='postgresql://prisma:prisma@localhost:5433/tests?schema=public' jest --coverage --runInBand --transformIgnorePatterns 'node_modules/(?!(dm3-lib-\\w*)/)'",
-    "build": "yarn tsc && cp ./config.yml ./dist/config.yml | true",
+    "build": "yarn tsc --declarationMap && cp ./config.yml ./dist/config.yml | true",
     "createDeliveryServiceProfile": "node --no-warnings ./cli.js",
     "before:tests": "docker-compose -f docker-compose.test.yml up -d && DATABASE_URL='postgresql://prisma:prisma@localhost:5433/tests?schema=public' yarn prisma-init"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,7 +28,7 @@
     "start": "yarn prisma-init && node  ./dist/index.js",
     "start-inspect": "node --inspect=0.0.0.0:9229  ./dist/index.js",
     "test": "yarn run before:tests && DATABASE_URL='postgresql://prisma:prisma@localhost:5433/tests?schema=public' jest --coverage --runInBand --transformIgnorePatterns 'node_modules/(?!(dm3-lib-\\w*)/)'",
-    "build": "yarn tsc --declarationMap && cp ./config.yml ./dist/config.yml | true",
+    "build": "yarn tsc && cp ./config.yml ./dist/config.yml | true",
     "createDeliveryServiceProfile": "node --no-warnings ./cli.js",
     "before:tests": "docker-compose -f docker-compose.test.yml up -d && DATABASE_URL='postgresql://prisma:prisma@localhost:5433/tests?schema=public' yarn prisma-init"
   },

--- a/packages/backend/src/profile.test.ts
+++ b/packages/backend/src/profile.test.ts
@@ -25,7 +25,7 @@ const web3ProviderMock: ethers.providers.JsonRpcProvider =
 
 const serverSecret = 'veryImportantSecretToGenerateAndValidateJSONWebTokens';
 
-let token = sign({ user: 'some.authenticated.user' }, serverSecret, {
+let token = sign({ user: 'alice.eth' }, serverSecret, {
     expiresIn: '1h',
 });
 
@@ -43,7 +43,7 @@ const setUpApp = async (
 const createDbMock = async () => {
     const sessionMocked = {
         challenge: '123',
-        token: token,
+        token: 'deprecated token that is not used anymore',
         signedUserProfile: {},
     } as Session & { spamFilterRules: spamFilter.SpamFilterRules };
 
@@ -53,7 +53,7 @@ const createDbMock = async () => {
                 Session & {
                     spamFilterRules: spamFilter.SpamFilterRules;
                 }
-            >(sessionMocked),
+            >(sessionMocked), // returns some valid session
         setSession: async (_: string, __: Session) => {},
         getIdEnsName: async (ensName: string) => ensName,
     };
@@ -69,7 +69,8 @@ describe('Profile', () => {
             const db = await createDbMock();
 
             const _web3Provider = {
-                resolveName: async () => 'some.ens.name',
+                resolveName: async () =>
+                    '0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5',
             };
             // I don't know why this function is needed in this test.
             // Remove it after storage migration.
@@ -78,7 +79,7 @@ describe('Profile', () => {
             setUpApp(app, db, web3ProviderMock);
 
             const response = await request(app)
-                .get('/some.user.we.want.to.get.profile.of')
+                .get('/alice.eth')
                 .set({
                     authorization: 'Bearer ' + token,
                 })

--- a/packages/backend/src/storage.ts
+++ b/packages/backend/src/storage.ts
@@ -11,6 +11,7 @@ import { ethers } from 'ethers';
 export default (
     db: IDatabase,
     web3Provider: ethers.providers.JsonRpcProvider,
+    serverSecret: string,
 ) => {
     const router = express.Router();
 
@@ -25,7 +26,7 @@ export default (
             next: NextFunction,
             ensName: string,
         ) => {
-            auth(req, res, next, ensName, db, web3Provider);
+            auth(req, res, next, ensName, db, web3Provider, serverSecret);
         },
     );
 

--- a/packages/delivery-service/package.json
+++ b/packages/delivery-service/package.json
@@ -27,7 +27,7 @@
     "start": "node  ./dist/index.js",
     "start-inspect": "node --inspect=0.0.0.0:9229  ./dist/index.js",
     "test": "yarn run before:tests &&  jest --coverage --runInBand --transformIgnorePatterns 'node_modules/(?!(dm3-lib-\\w*)/)'; yarn run after:tests",
-    "build": "yarn tsc --declarationMap && cp ./config.yml ./dist/config.yml | true",
+    "build": "yarn tsc && cp ./config.yml ./dist/config.yml | true",
     "createDeliveryServiceProfile": "node --no-warnings ./cli.js",
     "before:tests": "docker-compose -f docker-compose.test.yml up -d",
     "after:tests": "docker-compose -f docker-compose.test.yml down"

--- a/packages/delivery-service/package.json
+++ b/packages/delivery-service/package.json
@@ -27,7 +27,7 @@
     "start": "node  ./dist/index.js",
     "start-inspect": "node --inspect=0.0.0.0:9229  ./dist/index.js",
     "test": "yarn run before:tests &&  jest --coverage --runInBand --transformIgnorePatterns 'node_modules/(?!(dm3-lib-\\w*)/)'; yarn run after:tests",
-    "build": "yarn tsc && cp ./config.yml ./dist/config.yml | true",
+    "build": "yarn tsc --declarationMap && cp ./config.yml ./dist/config.yml | true",
     "createDeliveryServiceProfile": "node --no-warnings ./cli.js",
     "before:tests": "docker-compose -f docker-compose.test.yml up -d",
     "after:tests": "docker-compose -f docker-compose.test.yml down"

--- a/packages/delivery-service/package.json
+++ b/packages/delivery-service/package.json
@@ -17,7 +17,6 @@
     "dotenv": "^16.0.1",
     "ethers": "5.7.2",
     "express": "^4.18.1",
-    "prisma": "^5.10.1",
     "redis": "^4.1.0",
     "socket.io": "^4.5.1",
     "winston": "^3.8.1",
@@ -25,8 +24,7 @@
   },
   "scripts": {
     "docker:up": "docker-compose up -d",
-    "prisma-init": "prisma generate && prisma migrate dev ",
-    "start": "yarn prisma-init && node  ./dist/index.js",
+    "start": "node  ./dist/index.js",
     "start-inspect": "node --inspect=0.0.0.0:9229  ./dist/index.js",
     "test": "yarn run before:tests &&  jest --coverage --runInBand --transformIgnorePatterns 'node_modules/(?!(dm3-lib-\\w*)/)'; yarn run after:tests",
     "build": "yarn tsc && cp ./config.yml ./dist/config.yml | true",

--- a/packages/delivery-service/src/delivery.test.ts
+++ b/packages/delivery-service/src/delivery.test.ts
@@ -4,7 +4,6 @@ import request from 'supertest';
 import { Auth } from '@dm3-org/dm3-lib-server-side';
 import delivery from './delivery';
 import winston from 'winston';
-import { env } from 'process';
 
 const keysA = {
     encryptionKeyPair: {
@@ -30,19 +29,6 @@ describe('Delivery', () => {
                 resolveName: async () =>
                     '0x99C19AB10b9EC8aC6fcda9586E81f6B73a298870',
             };
-            const keys = {
-                signing: keysA.signingKeyPair,
-                encryption: keysA.encryptionKeyPair,
-            };
-            process.env.SIGNING_PUBLIC_KEY = keys.signing.publicKey;
-            process.env.SIGNING_PRIVATE_KEY = keys.signing.privateKey;
-            process.env.ENCRYPTION_PUBLIC_KEY = keys.encryption.publicKey;
-            process.env.ENCRYPTION_PRIVATE_KEY = keys.encryption.privateKey;
-
-            // const redisClient = {
-            //     exists: (_: any) => false,
-            // };
-
             const token = await createAuthToken();
 
             const db = {
@@ -65,7 +51,7 @@ describe('Delivery', () => {
             };
             const app = express();
             app.use(bodyParser.json());
-            app.use(delivery(web3Provider as any, db as any));
+            app.use(delivery(web3Provider as any, db as any, keysA));
 
             const { status } = await request(app)
                 .get('/messages/alice.eth/contact/bob.eth')
@@ -102,7 +88,7 @@ describe('Delivery', () => {
             };
             const app = express();
             app.use(bodyParser.json());
-            app.use(delivery(web3Provider as any, db as any));
+            app.use(delivery(web3Provider as any, db as any, keysA));
 
             // const redisClient = {
             //     exists: (_: any) => false,
@@ -149,7 +135,7 @@ describe('Delivery', () => {
             };
             const app = express();
             app.use(bodyParser.json());
-            app.use(delivery(web3Provider as any, db as any));
+            app.use(delivery(web3Provider as any, db as any, keysA));
 
             // const redisClient = {
             //     exists: (_: any) => false,
@@ -200,7 +186,7 @@ describe('Delivery', () => {
             };
             const app = express();
             app.use(bodyParser.json());
-            app.use(delivery(web3Provider as any, db as any));
+            app.use(delivery(web3Provider as any, db as any, keysA));
 
             // const redisClient = {
             //     exists: (_: any) => false,
@@ -242,7 +228,7 @@ describe('Delivery', () => {
             };
             const app = express();
             app.use(bodyParser.json());
-            app.use(delivery(web3Provider as any, db as any));
+            app.use(delivery(web3Provider as any, db as any, keysA));
 
             // const redisClient = {
             //     exists: (_: any) => false,

--- a/packages/delivery-service/src/delivery.test.ts
+++ b/packages/delivery-service/src/delivery.test.ts
@@ -1,9 +1,9 @@
+import { Auth } from '@dm3-org/dm3-lib-server-side';
 import bodyParser from 'body-parser';
 import express from 'express';
 import request from 'supertest';
-import { Auth } from '@dm3-org/dm3-lib-server-side';
-import delivery from './delivery';
 import winston from 'winston';
+import delivery from './delivery';
 
 const keysA = {
     encryptionKeyPair: {

--- a/packages/delivery-service/src/delivery.ts
+++ b/packages/delivery-service/src/delivery.ts
@@ -1,11 +1,12 @@
 import { Acknoledgment, getMessages, schema } from '@dm3-org/dm3-lib-delivery';
-import { auth, readKeysFromEnv } from '@dm3-org/dm3-lib-server-side';
+import { auth } from '@dm3-org/dm3-lib-server-side';
 import { validateSchema } from '@dm3-org/dm3-lib-shared';
 import { getConversationId } from '@dm3-org/dm3-lib-storage';
 import cors from 'cors';
 import { ethers } from 'ethers';
 import express from 'express';
 import { IDatabase } from './persistence/getDatabase';
+import { DeliveryServiceProfileKeys } from '@dm3-org/dm3-lib-profile';
 
 const syncAcknoledgmentParamsSchema = {
     type: 'object',
@@ -31,6 +32,7 @@ const syncAcknoledgmentBodySchema = {
 export default (
     web3Provider: ethers.providers.JsonRpcProvider,
     db: IDatabase,
+    keys: DeliveryServiceProfileKeys,
 ) => {
     const router = express.Router();
     //TODO remove
@@ -42,7 +44,6 @@ export default (
     router.get(
         '/messages/:ensName/contact/:contactEnsName',
         async (req: express.Request, res, next) => {
-            const keys = readKeysFromEnv(process.env);
             try {
                 const idEnsName = await db.getIdEnsName(req.params.ensName);
 
@@ -52,7 +53,7 @@ export default (
 
                 const newMessages = await getMessages(
                     db.getMessages,
-                    keys.encryption,
+                    keys.encryptionKeyPair,
                     idEnsName,
                     idContactEnsName,
                 );

--- a/packages/delivery-service/src/delivery.ts
+++ b/packages/delivery-service/src/delivery.ts
@@ -33,12 +33,13 @@ export default (
     web3Provider: ethers.providers.JsonRpcProvider,
     db: IDatabase,
     keys: DeliveryServiceProfileKeys,
+    serverSecret: string,
 ) => {
     const router = express.Router();
     //TODO remove
     router.use(cors());
     router.param('ensName', async (req, res, next, ensName: string) => {
-        auth(req, res, next, ensName, db, web3Provider);
+        auth(req, res, next, ensName, db, web3Provider, serverSecret);
     });
 
     router.get(

--- a/packages/delivery-service/src/delivery.ts
+++ b/packages/delivery-service/src/delivery.ts
@@ -129,7 +129,7 @@ export default (
             );
 
             if (!hasValidParams || !isLastMessagePullNumber || !hasValidBody) {
-                return res.send(400);
+                return res.sendStatus(400);
             }
 
             try {
@@ -178,7 +178,7 @@ export default (
             );
 
             if (!hasValidParams || !isLastMessagePullNumber || !hasValidBody) {
-                return res.send(400);
+                return res.sendStatus(400);
             }
 
             try {

--- a/packages/delivery-service/src/index.ts
+++ b/packages/delivery-service/src/index.ts
@@ -1,6 +1,15 @@
+import {
+    errorHandler,
+    getWeb3Provider,
+    logError,
+    logRequest,
+    socketAuth,
+} from '@dm3-org/dm3-lib-server-side';
+import { logInfo } from '@dm3-org/dm3-lib-shared';
 import { Axios } from 'axios';
 import bodyParser from 'body-parser';
 import cors from 'cors';
+import 'dotenv/config';
 import express from 'express';
 import http from 'http';
 import path from 'path';
@@ -10,20 +19,10 @@ import { startCleanUpPendingMessagesJob } from './cleanup/cleanUpPendingMessages
 import { getDeliveryServiceProperties } from './config/getDeliveryServiceProperties';
 import Delivery from './delivery';
 import { onConnection } from './messaging';
+import Notifications from './notifications';
 import { getDatabase } from './persistence/getDatabase';
 import Profile from './profile';
 import RpcProxy from './rpc/rpc-proxy';
-import { logInfo } from '@dm3-org/dm3-lib-shared';
-import 'dotenv/config';
-
-import {
-    errorHandler,
-    getWeb3Provider,
-    logError,
-    logRequest,
-    socketAuth,
-} from '@dm3-org/dm3-lib-server-side';
-import Notifications from './notifications';
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));

--- a/packages/delivery-service/src/messaging.test.ts
+++ b/packages/delivery-service/src/messaging.test.ts
@@ -2,12 +2,12 @@ import express from 'express';
 import { Socket } from 'socket.io';
 import { onConnection } from './messaging';
 import { testData } from '../../../test-data/encrypted-envelops.test';
-import { WithLocals } from './types';
 import { Session } from '@dm3-org/dm3-lib-delivery';
 import { UserProfile } from '@dm3-org/dm3-lib-profile';
 import { createKeyPair } from '@dm3-org/dm3-lib-crypto';
 import { ethersHelper } from '@dm3-org/dm3-lib-shared';
 import winston from 'winston';
+import { getWeb3Provider } from '../../lib/server-side/dist/utils';
 const SENDER_ADDRESS = '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292';
 const RECEIVER_ADDRESS = '0xDd36ae7F9a8E34FACf1e110c6e9d37D0dc917855';
 
@@ -29,308 +29,6 @@ const keysA = {
 };
 
 const keyPair = createKeyPair();
-
-describe('Messaging', () => {
-    describe('submitMessage', () => {
-        it('returns success if schema is valid', (done: any) => {
-            //We expect the callback functions called once witht he value 'success'
-            expect.assertions(1);
-            const callback = (e: any) => {
-                // eslint-disable-next-line max-len
-                //Even though the method fails jest dosen't recognize it becuase of the catch block used in messaging.ts. So we have to throw another error if the callback returns anything else then the expected result.
-                if (e.response !== 'success') {
-                    throw Error(e);
-                }
-                expect(e.response).toBe('success');
-                done();
-            };
-            //We provide an mocked express app with all needes locals vars
-            const app = {
-                locals: {
-                    logger,
-                    keys: {
-                        signing: keysA.signingKeyPair,
-                        encryption: keysA.encryptionKeyPair,
-                    },
-
-                    deliveryServiceProperties: {
-                        sizeLimit: 2 ** 14,
-                        notificationChannel: [],
-                    },
-                    web3Provider: {
-                        resolveName: async () =>
-                            '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
-                    },
-
-                    db: {
-                        getSession,
-                        createMessage: () => {},
-                        getIdEnsName: async (ensName: string) => ensName,
-                        getUsersNotificationChannels: () => Promise.resolve([]),
-                    },
-                    io: {
-                        sockets: {
-                            to: (_: any) => ({
-                                emit: (_: any, __any: any) => {},
-                            }),
-                        },
-                    },
-                } as any,
-            } as express.Express & WithLocals;
-
-            //The same data used in Messages.test
-            const data = {
-                envelop: testData.envelopA,
-                token: '123',
-            };
-
-            const getSocketMock = () => {
-                return {
-                    on: async (name: string, onSubmitMessage: any) => {
-                        //We just want to test the submitMessage callback fn
-                        if (name === 'submitMessage') {
-                            await onSubmitMessage(data, callback);
-                        }
-                    },
-                } as unknown as Socket;
-            };
-
-            onConnection(app)(getSocketMock());
-        });
-        it('sends notification after message was submitted', (done: any) => {
-            //We expect the callback functions called once witht he value 'success'
-            expect.assertions(1);
-            const callback = (e: any) => {
-                // eslint-disable-next-line max-len
-                //Even though the method fails jest dosen't recognize it becuase of the catch block used in messaging.ts. So we have to throw another error if the callback returns anything else then the expected result.
-                if (e.response !== 'success') {
-                    throw Error(e);
-                }
-                expect(e.response).toBe('success');
-                done();
-            };
-            //We provide an mocked express app with all needes locals vars
-            const app = {
-                locals: {
-                    logger,
-                    keys: {
-                        signing: keysA.signingKeyPair,
-                        encryption: keysA.encryptionKeyPair,
-                    },
-
-                    deliveryServiceProperties: {
-                        sizeLimit: 2 ** 14,
-                        notificationChannel: [],
-                    },
-                    web3Provider: {
-                        resolveName: async () =>
-                            '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
-                    },
-
-                    db: {
-                        getSession,
-                        createMessage: () => {},
-                        getIdEnsName: async (ensName: string) => ensName,
-                        getUsersNotificationChannels: () => Promise.resolve([]),
-                    },
-                    io: {
-                        sockets: {
-                            to: (_: any) => ({
-                                emit: (_: any, __any: any) => {},
-                            }),
-                        },
-                    },
-                } as any,
-            } as express.Express & WithLocals;
-
-            //The same data used in Messages.test
-            const data = {
-                envelop: testData.envelopA,
-                token: '123',
-            };
-
-            const getSocketMock = () => {
-                return {
-                    on: async (name: string, onSubmitMessage: any) => {
-                        //We just want to test the submitMessage callback fn
-                        if (name === 'submitMessage') {
-                            await onSubmitMessage(data, callback);
-                        }
-                    },
-                } as unknown as Socket;
-            };
-
-            onConnection(app)(getSocketMock());
-        });
-        it.skip('returns error if message is spam', (done: any) => {
-            //We expect the callback functions called once witht he value 'success'
-            expect.assertions(1);
-            const callback = jest.fn((e: any) => {
-                // eslint-disable-next-line max-len
-                //Even though the method fails jest dosen't recognize it becuase of the catch block used in messaging.ts. So we have to throw another error if the callback returns anything else then the expected result.
-                if (e.error !== 'Message does not match spam criteria') {
-                    throw Error(e);
-                }
-                expect(e.error).toBe('Message does not match spam criteria');
-                done();
-            });
-            const session = async (addr: string) => {
-                return {
-                    ...(await getSession(addr)),
-                    spamFilterRules: { minNonce: 2 },
-                } as Session;
-            };
-            //We provide an mocked express app with all needes locals vars
-
-            const app = {
-                locals: {
-                    logger,
-                    keys: {
-                        signing: keysA.signingKeyPair,
-                        encryption: keysA.encryptionKeyPair,
-                    },
-
-                    deliveryServiceProperties: {
-                        sizeLimit: 2 ** 14,
-                        notificationChannel: [],
-                    },
-
-                    db: {
-                        getSession: session,
-                        createMessage: () => {},
-                        getIdEnsName: async (ensName: string) => ensName,
-                        getUsersNotificationChannels: () => Promise.resolve([]),
-                    },
-                    web3Provider: {
-                        getTransactionCount: (_: string) => Promise.resolve(0),
-                        resolveName: async () =>
-                            '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
-                    },
-                    redisClient: {
-                        zAdd: () => {},
-                    },
-                    io: {
-                        sockets: {
-                            to: (_: any) => ({
-                                emit: (_: any, __any: any) => {},
-                            }),
-                        },
-                    },
-                } as any,
-            } as express.Express & WithLocals;
-
-            //The same data used in Messages.test
-            const data = {
-                envelop: testData.envelopA,
-                token: '123',
-            };
-
-            const getSocketMock = () => {
-                return {
-                    on: async (name: string, onSubmitMessage: any) => {
-                        //We just want to test the submitMessage callback fn
-                        if (name === 'submitMessage') {
-                            await onSubmitMessage(data, callback);
-                        }
-                    },
-                } as unknown as Socket;
-            };
-
-            onConnection(app)(getSocketMock());
-        });
-        it('Throws error if schema is invalid', async () => {
-            //We expect the callback functions called once witht he value 'success'
-            expect.assertions(1);
-            const callback = jest.fn((e: any) => {
-                // eslint-disable-next-line max-len
-                //Even though the method fails jest dosen't recognize it becuase of the catch block used in messaging.ts. So we have to throw another error if the callback returns anything else then the expected result.
-                if (e.error !== 'invalid schema') {
-                    throw Error(e);
-                }
-                expect(e.error).toBe('invalid schema');
-            });
-            //We provide an mocked express app with all needes locals vars
-            const app = {
-                locals: {
-                    logger,
-                    deliveryServicePrivateKey:
-                        '9SZhajjn9tn0fX/eBMXfZfb0RaUeYyfhlNYHqZyKHpyTiYvwVosQ5qt2XxdDFblTzggir8kp85kWw76p2EZ0rQ==',
-                    redisClient: {
-                        zAdd: () => {},
-                    },
-                    io: {
-                        sockets: {
-                            to: (_: any) => ({
-                                emit: (_: any, __any: any) => {},
-                            }),
-                        },
-                    },
-                    db: {
-                        getSession,
-                        getIdEnsName: async (ensName: string) => ensName,
-                        getUsersNotificationChannels: () => Promise.resolve([]),
-                    },
-                } as any,
-            } as express.Express & WithLocals;
-
-            //The same data used in Messages.test
-            const data = {
-                envelop: {
-                    foo: 'bar',
-                },
-                token: '123',
-            };
-
-            const getSocketMock = jest.fn(() => {
-                return {
-                    on: async (name: string, onSubmitMessage: any) => {
-                        //We just want to test the submitMessage callback fn
-                        if (name === 'submitMessage') {
-                            await onSubmitMessage(data, callback);
-                        }
-                    },
-                } as unknown as Socket;
-            });
-
-            await onConnection(app)(getSocketMock());
-        });
-    });
-
-    describe('pendingMessage', () => {
-        it('returns error if schema is invalid', async () => {
-            const app = {
-                locals: {
-                    logger,
-                } as any,
-            } as express.Express & WithLocals;
-
-            const data = {
-                accountAddress: '',
-                contactAddress: '',
-            };
-
-            const callback = jest.fn((e: any) => {
-                if (e.error !== 'invalid schema') {
-                    throw Error(e);
-                }
-                expect(e.error).toBe('invalid schema');
-            });
-
-            const getSocketMock = jest.fn(() => {
-                return {
-                    on: async (name: string, onPendingMessage: any) => {
-                        //We just want to test the submitMessage callback fn
-                        if (name === 'pendingMessage') {
-                            await onPendingMessage(data, callback);
-                        }
-                    },
-                } as unknown as Socket;
-            });
-
-            await onConnection(app)(getSocketMock());
-        });
-    });
-});
 
 const getSession = async (address: string) => {
     const emptyProfile: UserProfile = {
@@ -363,3 +61,173 @@ const getSession = async (address: string) => {
 
     return null;
 };
+
+describe('Messaging', () => {
+    // prepare some mocks that are used by many tests
+    const web3Provider = {
+        resolveName: async () => '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
+    };
+    const db = {
+        getSession,
+        createMessage: () => {},
+        getIdEnsName: async (ensName: string) => ensName,
+        getUsersNotificationChannels: () => Promise.resolve([]),
+    };
+    const io = {
+        sockets: {
+            to: (_: any) => ({
+                emit: (_: any, __any: any) => {},
+            }),
+        },
+    };
+    //The same data used in Messages.test
+    const data = {
+        envelop: testData.envelopA,
+        token: '123',
+    };
+
+    describe('submitMessage', () => {
+        it('returns success if schema is valid', (done: any) => {
+            //We expect the callback function to be called once with
+            // the value 'success'
+            expect.assertions(1);
+
+            const callback = (e: any) => {
+                // Even though the method fails jest doesn't recognize it because
+                // of the catch block used in messaging.ts. So we have to throw
+                // another error if the callback returns anything else then the expected
+                // result.
+                expect(e.response).toBe('success');
+                done();
+            };
+
+            const getSocketMock = () => {
+                return {
+                    on: async (name: string, onSubmitMessage: any) => {
+                        //We just want to test the submitMessage callback fn
+                        if (name === 'submitMessage') {
+                            await onSubmitMessage(data, callback);
+                        }
+                    },
+                } as unknown as Socket;
+            };
+
+            onConnection(
+                io as any,
+                web3Provider as any,
+                db as any,
+                keysA,
+            )(getSocketMock());
+        });
+        it.skip('returns error if message is spam', (done: any) => {
+            //We expect the callback functions called once with the value 'success'
+            expect.assertions(1);
+            const callback = jest.fn((e: any) => {
+                /*
+                 * Even though the method fails jest dosen't recognize it because of the catch block
+                 * used in messaging.ts. So we have to throw another error if the callback returns
+                 * anything else then the expected result.
+                 */
+                expect(e.error).toBe('Message does not match spam criteria');
+                done();
+            });
+
+            const session = async (addr: string) => {
+                return {
+                    ...(await getSession(addr)),
+                    spamFilterRules: { minNonce: 2 },
+                } as Session;
+            };
+            const db = {
+                getSession: session,
+                createMessage: () => {},
+                getIdEnsName: async (ensName: string) => ensName,
+                getUsersNotificationChannels: () => Promise.resolve([]),
+            };
+
+            const getSocketMock = () => {
+                return {
+                    on: async (name: string, onSubmitMessage: any) => {
+                        //We just want to test the submitMessage callback fn
+                        if (name === 'submitMessage') {
+                            await onSubmitMessage(data, callback);
+                        }
+                    },
+                } as unknown as Socket;
+            };
+
+            onConnection(
+                io as any,
+                web3Provider as any,
+                db as any,
+                keysA,
+            )(getSocketMock());
+        });
+        it('Throws error if schema is invalid', async () => {
+            expect.assertions(1);
+            const callback = jest.fn((e: any) => {
+                /**
+                 * Even though the method fails jest dosen't recognize it because of the
+                 * catch block used in messaging.ts. So we have to throw another error if
+                 * the callback returns anything else then the expected result.
+                 */
+                expect(e.error).toBe('invalid schema');
+            });
+
+            const localData = { ...data };
+            const metadata = localData.envelop.metadata as any;
+            // Change the data so it becomes invalid in order to provoke the 'invalid schema' error
+            delete metadata.deliveryInformation;
+            localData.envelop.metadata = metadata;
+
+            const getSocketMock = jest.fn(() => {
+                return {
+                    on: async (name: string, onSubmitMessage: any) => {
+                        //We just want to test the submitMessage callback fn
+                        if (name === 'submitMessage') {
+                            await onSubmitMessage(localData, await callback);
+                        }
+                    },
+                } as unknown as Socket;
+            });
+
+            onConnection(
+                io as any,
+                web3Provider as any,
+                db as any,
+                keysA,
+            )(getSocketMock());
+        });
+    });
+
+    describe('pendingMessage', () => {
+        it('returns error if schema is invalid', async () => {
+            const data = {
+                accountAddress: '',
+                contactAddress: '',
+            };
+            const callback = jest.fn((e: any) => {
+                if (e.error !== 'invalid schema') {
+                    throw Error(e);
+                }
+                expect(e.error).toBe('invalid schema');
+            });
+            const getSocketMock = jest.fn(() => {
+                return {
+                    on: async (name: string, onPendingMessage: any) => {
+                        //We just want to test the submitMessage callback fn
+                        if (name === 'pendingMessage') {
+                            await onPendingMessage(data, callback);
+                        }
+                    },
+                } as unknown as Socket;
+            });
+            onConnection(
+                io as any,
+                web3Provider as any,
+                db as any,
+                keysA,
+            )(getSocketMock());
+        });
+    });
+});

--- a/packages/delivery-service/src/messaging.test.ts
+++ b/packages/delivery-service/src/messaging.test.ts
@@ -1,13 +1,11 @@
-import express from 'express';
-import { Socket } from 'socket.io';
-import { onConnection } from './messaging';
-import { testData } from '../../../test-data/encrypted-envelops.test';
+import { createKeyPair } from '@dm3-org/dm3-lib-crypto';
 import { Session } from '@dm3-org/dm3-lib-delivery';
 import { UserProfile } from '@dm3-org/dm3-lib-profile';
-import { createKeyPair } from '@dm3-org/dm3-lib-crypto';
 import { ethersHelper } from '@dm3-org/dm3-lib-shared';
+import { Socket } from 'socket.io';
 import winston from 'winston';
-import { getWeb3Provider } from '../../lib/server-side/dist/utils';
+import { testData } from '../../../test-data/encrypted-envelops.test';
+import { onConnection } from './messaging';
 const SENDER_ADDRESS = '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292';
 const RECEIVER_ADDRESS = '0xDd36ae7F9a8E34FACf1e110c6e9d37D0dc917855';
 
@@ -87,7 +85,7 @@ describe('Messaging', () => {
     };
 
     describe('submitMessage', () => {
-        it('returns success if schema is valid', (done: any) => {
+        it.only('returns success if schema is valid', (done: any) => {
             //We expect the callback function to be called once with
             // the value 'success'
             expect.assertions(1);

--- a/packages/delivery-service/src/messaging.test.ts
+++ b/packages/delivery-service/src/messaging.test.ts
@@ -81,11 +81,47 @@ describe('Messaging', () => {
     //The same data used in Messages.test
     const data = {
         envelop: testData.envelopA,
-        token: '123',
+        //token: '123',
     };
 
     describe('submitMessage', () => {
-        it.only('returns success if schema is valid', (done: any) => {
+        it('returns success if schema is valid', (done: any) => {
+            //We expect the callback function to be called once with
+            // the value 'success'
+            expect.assertions(1);
+
+            const callback = (e: any) => {
+                // Even though the method fails jest doesn't recognize it because
+                // of the catch block used in messaging.ts. So we have to throw
+                // another error if the callback returns anything else then the expected
+                // result.
+                expect(e.response).toBe('success');
+                done();
+            };
+
+            const getSocketMock = () => {
+                return {
+                    on: async (name: string, onSubmitMessage: any) => {
+                        //We just want to test the submitMessage callback fn
+                        if (name === 'submitMessage') {
+                            await onSubmitMessage(
+                                { ...data, token: '123' },
+                                callback,
+                            );
+                        }
+                    },
+                } as unknown as Socket;
+            };
+
+            onConnection(
+                io as any,
+                web3Provider as any,
+                db as any,
+                keysA,
+            )(getSocketMock());
+        });
+
+        it('returns success even without token if schema is valid', (done: any) => {
             //We expect the callback function to be called once with
             // the value 'success'
             expect.assertions(1);

--- a/packages/delivery-service/src/messaging.ts
+++ b/packages/delivery-service/src/messaging.ts
@@ -56,7 +56,7 @@ export function onConnection(
 
                     const isSchemaValid = validateSchema(
                         schema.EncryptionEnvelopeSchema,
-                        data,
+                        data.envelop,
                     );
 
                     if (!isSchemaValid) {

--- a/packages/delivery-service/src/messaging.ts
+++ b/packages/delivery-service/src/messaging.ts
@@ -26,6 +26,7 @@ export function onConnection(
     web3Provider: ethers.providers.JsonRpcProvider,
     db: IDatabase,
     keys: DeliveryServiceProfileKeys,
+    serverSecret: string,
 ) {
     return (socket: Socket) => {
         socket.on('disconnect', () => {
@@ -146,6 +147,7 @@ export function onConnection(
                         db.getSession,
                         idEnsName,
                         data.token,
+                        serverSecret,
                     ))
                 ) {
                     const error = 'Token check failed';

--- a/packages/delivery-service/src/messaging.ts
+++ b/packages/delivery-service/src/messaging.ts
@@ -1,5 +1,5 @@
-import { checkToken, incomingMessage, schema } from '@dm3-org/dm3-lib-delivery';
-import { EncryptionEnvelop } from '@dm3-org/dm3-lib-messaging';
+import { checkToken, incomingMessage } from '@dm3-org/dm3-lib-delivery';
+import { EncryptionEnvelop, schema } from '@dm3-org/dm3-lib-messaging';
 import {
     DeliveryServiceProfileKeys,
     normalizeEnsName,
@@ -55,7 +55,7 @@ export function onConnection(
                     });
 
                     const isSchemaValid = validateSchema(
-                        schema.MessageSubmission,
+                        schema.EncryptionEnvelopeSchema,
                         data,
                     );
 
@@ -75,7 +75,7 @@ export function onConnection(
                     });
 
                     await incomingMessage(
-                        data,
+                        data.envelop,
                         keys.signingKeyPair,
                         keys.encryptionKeyPair,
                         deliveryServiceProperties.sizeLimit,

--- a/packages/delivery-service/src/notifications.test.ts
+++ b/packages/delivery-service/src/notifications.test.ts
@@ -1,10 +1,8 @@
-import { Auth, getWeb3Provider } from '@dm3-org/dm3-lib-server-side';
+import { Auth } from '@dm3-org/dm3-lib-server-side';
 import bodyParser from 'body-parser';
 import express from 'express';
 import request from 'supertest';
 import notifications from './notifications';
-import { getDatabase, IDatabase } from './persistence/getDatabase';
-import { ethers } from 'ethers';
 
 import {
     DeliveryServiceProperties,

--- a/packages/delivery-service/src/notifications.ts
+++ b/packages/delivery-service/src/notifications.ts
@@ -26,6 +26,7 @@ export default (
     deliveryServiceProperties: DeliveryServiceProperties,
     db: IDatabase,
     web3Provider: ethers.providers.JsonRpcProvider,
+    serverSecret: string,
 ) => {
     const router = express.Router();
 
@@ -34,7 +35,7 @@ export default (
 
     // Adding a route parameter middleware named 'ensName'
     router.param('ensName', (req, res, next, ensName: string) => {
-        auth(req, res, next, ensName, db, web3Provider);
+        auth(req, res, next, ensName, db, web3Provider, serverSecret);
     });
 
     // Defining a route to enable/disable global notifications

--- a/packages/delivery-service/src/profile.ts
+++ b/packages/delivery-service/src/profile.ts
@@ -13,79 +13,70 @@ export default (
 ) => {
     const router = express.Router();
 
-    router.get(
-        '/:ensName',
-        //@ts-ignore
-        async (req: express.Request, res, next) => {
-            try {
-                const ensName = normalizeEnsName(req.params.ensName);
+    router.get('/:ensName', async (req: express.Request, res, next) => {
+        try {
+            const ensName = normalizeEnsName(req.params.ensName);
 
-                const profile = await getUserProfile(db.getSession, ensName);
-                if (profile) {
-                    res.json(profile);
-                } else {
-                    res.sendStatus(404);
-                }
-            } catch (e) {
-                next(e);
+            const profile = await getUserProfile(db.getSession, ensName);
+            if (profile) {
+                res.json(profile);
+            } else {
+                res.sendStatus(404);
             }
-        },
-    );
+        } catch (e) {
+            next(e);
+        }
+    });
 
-    router.post(
-        '/:ensName',
-        //@ts-ignore
-        async (req: express.Request, res, next) => {
-            try {
-                const schemaIsValid = validateSchema(
-                    schema.SignedUserProfile,
-                    req.body,
-                );
+    router.post('/:ensName', async (req: express.Request, res, next) => {
+        try {
+            const schemaIsValid = validateSchema(
+                schema.SignedUserProfile,
+                req.body,
+            );
 
-                if (!schemaIsValid) {
-                    global.logger.error({ message: 'invalid schema' });
-                    return res.status(400).send({ error: 'invalid schema' });
-                }
-                const ensName = normalizeEnsName(req.params.ensName);
-                global.logger.debug({
-                    method: 'POST',
-                    url: req.url,
-                    ensName,
-                    disableSessionCheck:
-                        process.env.DISABLE_SESSION_CHECK === 'true',
-                });
-
-                const data = await submitUserProfile(
-                    web3Provider,
-                    db.getSession,
-                    db.setSession,
-                    ensName,
-                    req.body,
-                    (ensName: string) => db.getPending(ensName),
-                    (socketId: string) =>
-                        io.sockets.to(socketId).emit('joined'),
-                );
-                global.logger.debug({
-                    message: 'POST profile',
-                    ensName,
-                    data,
-                });
-
-                res.json(data);
-            } catch (e) {
-                global.logger.warn({
-                    message: 'POST profile',
-                    error: JSON.stringify(e),
-                });
-                // eslint-disable-next-line no-console
-                console.log('POST PROFILE ERROR', e);
-                res.status(400).send({
-                    message: `Couldn't store profile`,
-                    error: JSON.stringify(e),
-                });
+            if (!schemaIsValid) {
+                global.logger.error({ message: 'invalid schema' });
+                return res.status(400).send({ error: 'invalid schema' });
             }
-        },
-    );
+            const ensName = normalizeEnsName(req.params.ensName);
+            global.logger.debug({
+                method: 'POST',
+                url: req.url,
+                ensName,
+                disableSessionCheck:
+                    process.env.DISABLE_SESSION_CHECK === 'true',
+            });
+
+            const data = await submitUserProfile(
+                web3Provider,
+                db.getSession,
+                db.setSession,
+                ensName,
+                req.body,
+                (ensName: string) => db.getPending(ensName),
+                (socketId: string) => io.sockets.to(socketId).emit('joined'),
+            );
+            global.logger.debug({
+                message: 'POST profile',
+                ensName,
+                data,
+            });
+
+            res.json(data);
+        } catch (e) {
+            global.logger.warn({
+                message: 'POST profile',
+                error: JSON.stringify(e),
+            });
+            // eslint-disable-next-line no-console
+            console.log('POST PROFILE ERROR', e);
+            res.status(400).send({
+                message: `Couldn't store profile`,
+                error: JSON.stringify(e),
+            });
+        }
+    });
 
     return router;
 };

--- a/packages/delivery-service/src/rpc/methods/handleSubmitMessage.ts
+++ b/packages/delivery-service/src/rpc/methods/handleSubmitMessage.ts
@@ -5,12 +5,12 @@ import {
 } from '@dm3-org/dm3-lib-delivery';
 import { EncryptionEnvelop } from '@dm3-org/dm3-lib-messaging';
 import { validateSchema, logError } from '@dm3-org/dm3-lib-shared';
-import { readKeysFromEnv } from '@dm3-org/dm3-lib-server-side';
 import 'dotenv/config';
 import express from 'express';
 import { Server } from 'socket.io';
 import { IDatabase } from '../../persistence/getDatabase';
 import { ethers } from 'ethers';
+import { DeliveryServiceProfileKeys } from '@dm3-org/dm3-lib-profile';
 
 export async function handleSubmitMessage(
     req: express.Request,
@@ -19,6 +19,7 @@ export async function handleSubmitMessage(
     deliveryServiceProperties: DeliveryServiceProperties,
     web3Provider: ethers.providers.JsonRpcProvider,
     db: IDatabase,
+    keys: DeliveryServiceProfileKeys,
 ) {
     const {
         params: [stringifiedEnvelop, token],
@@ -52,13 +53,11 @@ export async function handleSubmitMessage(
         return res.status(400).send({ error });
     }
 
-    const keys = readKeysFromEnv(process.env);
-
     try {
         await incomingMessage(
             { envelop, token },
-            keys.signing,
-            keys.encryption,
+            keys.signingKeyPair,
+            keys.encryptionKeyPair,
             deliveryServiceProperties.sizeLimit,
             deliveryServiceProperties.notificationChannel,
             db.getSession,

--- a/packages/delivery-service/src/rpc/methods/handleSubmitMessage.ts
+++ b/packages/delivery-service/src/rpc/methods/handleSubmitMessage.ts
@@ -25,17 +25,24 @@ export async function handleSubmitMessage(
         params: [stringifiedEnvelop, token],
     } = req.body;
 
-    const envelop = JSON.parse(stringifiedEnvelop);
-
     if (!token) {
         logError('Auth token missing');
         return res.status(400).send('Auth token missing');
     }
 
-    if (!envelop) {
+    if (!stringifiedEnvelop) {
         logError('Envelop missing');
 
         return res.status(400).send('Envelop missing');
+    }
+
+    let envelop;
+    try {
+        envelop = JSON.parse(stringifiedEnvelop);
+    } catch (error) {
+        logError('Error parsing envelop');
+
+        return res.status(400).send('Error parsing envelop');
     }
 
     const isSchemaValid = validateSchema(schema.MessageSubmission, {

--- a/packages/delivery-service/src/rpc/methods/handleSubmitMessage.ts
+++ b/packages/delivery-service/src/rpc/methods/handleSubmitMessage.ts
@@ -1,9 +1,8 @@
 import {
-    schema,
     incomingMessage,
     DeliveryServiceProperties,
 } from '@dm3-org/dm3-lib-delivery';
-import { EncryptionEnvelop } from '@dm3-org/dm3-lib-messaging';
+import { EncryptionEnvelop, schema } from '@dm3-org/dm3-lib-messaging';
 import { validateSchema, logError } from '@dm3-org/dm3-lib-shared';
 import 'dotenv/config';
 import express from 'express';
@@ -22,13 +21,8 @@ export async function handleSubmitMessage(
     keys: DeliveryServiceProfileKeys,
 ) {
     const {
-        params: [stringifiedEnvelop, token],
+        params: [stringifiedEnvelop],
     } = req.body;
-
-    if (!token) {
-        logError('Auth token missing');
-        return res.status(400).send('Auth token missing');
-    }
 
     if (!stringifiedEnvelop) {
         logError('Envelop missing');
@@ -45,10 +39,10 @@ export async function handleSubmitMessage(
         return res.status(400).send('Error parsing envelop');
     }
 
-    const isSchemaValid = validateSchema(schema.MessageSubmission, {
+    const isSchemaValid = validateSchema(
+        schema.EncryptionEnvelopeSchema,
         envelop,
-        token,
-    });
+    );
 
     if (!isSchemaValid) {
         const error = 'invalid schema';
@@ -62,7 +56,7 @@ export async function handleSubmitMessage(
 
     try {
         await incomingMessage(
-            { envelop, token },
+            envelop,
             keys.signingKeyPair,
             keys.encryptionKeyPair,
             deliveryServiceProperties.sizeLimit,

--- a/packages/delivery-service/src/rpc/rpc-proxy.test.ts
+++ b/packages/delivery-service/src/rpc/rpc-proxy.test.ts
@@ -22,23 +22,22 @@ const RECEIVER_ADDRESS = '0xDd36ae7F9a8E34FACf1e110c6e9d37D0dc917855';
 
 const keyPair = createKeyPair();
 
+const keysA = {
+    encryptionKeyPair: {
+        publicKey: 'eHmMq29FeiPKfNPkSctPuZGXvV0sKeO/KZkX2nXvMgw=',
+        privateKey: 'pMI77F2w3GK+omZCB4A61WDqISOOnWGXR2f/MTLbqbY=',
+    },
+    signingKeyPair: {
+        publicKey: '+tkDQWZfv9ixBmObsf8tgTHTZajwAE9muTtFAUj2e9I=',
+        privateKey:
+            '+DpeBjCzICFoi743/466yJunsHR55Bhr3GnqcS4cuJX62QNBZl+/2LEGY5ux/y2BMdNlqPAAT2a5O0UBSPZ70g==',
+    },
+    storageEncryptionKey: '+DpeBjCzICFoi743/466yJunsHR55Bhr3GnqcS4cuJU=',
+    storageEncryptionNonce: 0,
+};
+
 describe('rpc-Proxy', () => {
     describe('routing', () => {
-        const keysA = {
-            encryptionKeyPair: {
-                publicKey: 'eHmMq29FeiPKfNPkSctPuZGXvV0sKeO/KZkX2nXvMgw=',
-                privateKey: 'pMI77F2w3GK+omZCB4A61WDqISOOnWGXR2f/MTLbqbY=',
-            },
-            signingKeyPair: {
-                publicKey: '+tkDQWZfv9ixBmObsf8tgTHTZajwAE9muTtFAUj2e9I=',
-                privateKey:
-                    '+DpeBjCzICFoi743/466yJunsHR55Bhr3GnqcS4cuJX62QNBZl+/2LEGY5ux/y2BMdNlqPAAT2a5O0UBSPZ70g==',
-            },
-            storageEncryptionKey:
-                '+DpeBjCzICFoi743/466yJunsHR55Bhr3GnqcS4cuJU=',
-            storageEncryptionNonce: 0,
-        };
-
         it('Should route non-dm3 related messages to the rpc node', async () => {
             const mockPost = jest.fn((url: string, body: any) => {
                 return Promise.resolve({ data: 'Forwarded' });
@@ -56,6 +55,7 @@ describe('rpc-Proxy', () => {
                     {} as any,
                     {} as any,
                     {} as any,
+                    keysA,
                 ),
             );
 
@@ -123,6 +123,7 @@ describe('rpc-Proxy', () => {
                     io as any,
                     web3Provider as any,
                     db as any,
+                    keysA,
                 ),
             );
 
@@ -175,6 +176,7 @@ describe('rpc-Proxy', () => {
                     {} as any,
                     {} as any,
                     {} as any,
+                    keysA,
                 ),
             );
 
@@ -213,6 +215,7 @@ describe('rpc-Proxy', () => {
                     {} as any,
                     {} as any,
                     {} as any,
+                    keysA,
                 ),
             );
 
@@ -252,6 +255,7 @@ describe('rpc-Proxy', () => {
                     {} as any,
                     web3Provider as any,
                     db as any,
+                    keysA,
                 ),
             );
 
@@ -315,6 +319,7 @@ describe('rpc-Proxy', () => {
                     {} as any,
                     web3Provider as any,
                     db as any,
+                    keysA,
                 ),
             );
 

--- a/packages/delivery-service/src/rpc/rpc-proxy.test.ts
+++ b/packages/delivery-service/src/rpc/rpc-proxy.test.ts
@@ -100,10 +100,6 @@ describe('rpc-Proxy', () => {
                 resolveName: async () =>
                     '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
             };
-            const loadSession = getSession;
-            const redisClient = {
-                zAdd: () => {},
-            };
             const db = {
                 createMessage: () => {},
                 getSession,

--- a/packages/delivery-service/src/rpc/rpc-proxy.test.ts
+++ b/packages/delivery-service/src/rpc/rpc-proxy.test.ts
@@ -2,8 +2,8 @@ import { Axios } from 'axios';
 import bodyParser from 'body-parser';
 import express from 'express';
 import request from 'supertest';
-import RpcProxy from './rpc-proxy';
 import { testData } from '../../../../test-data/encrypted-envelops.test';
+import RpcProxy from './rpc-proxy';
 
 import { createKeyPair } from '@dm3-org/dm3-lib-crypto';
 import { normalizeEnsName, UserProfile } from '@dm3-org/dm3-lib-profile';

--- a/packages/delivery-service/src/rpc/rpc-proxy.test.ts
+++ b/packages/delivery-service/src/rpc/rpc-proxy.test.ts
@@ -38,19 +38,12 @@ const keysA = {
 
 describe('rpc-Proxy', () => {
     describe('routing', () => {
-        it('Should route non-dm3 related messages to the rpc node', async () => {
-            const mockPost = jest.fn((url: string, body: any) => {
-                return Promise.resolve({ data: 'Forwarded' });
-            });
-            const axiosMock = {
-                post: mockPost,
-            } as Partial<Axios>;
-
+        it.only('Should block non-dm3 related requests', async () => {
             const app = express();
             app.use(bodyParser.json());
             app.use(
                 RpcProxy(
-                    axiosMock as Axios,
+                    {} as any,
                     {} as any,
                     {} as any,
                     {} as any,
@@ -59,7 +52,7 @@ describe('rpc-Proxy', () => {
                 ),
             );
 
-            const { body } = await request(app)
+            const { status, body } = await request(app)
                 .post('/')
                 .send({
                     jsonrpc: '2.0',
@@ -71,8 +64,8 @@ describe('rpc-Proxy', () => {
                     id: 1,
                 });
 
-            expect(body).toBe('Forwarded');
-            expect(mockPost).toBeCalled();
+            expect(body).toStrictEqual({ error: 'Method not allowed' });
+            expect(status).toBe(405);
 
             return;
         });

--- a/packages/delivery-service/src/rpc/rpc-proxy.test.ts
+++ b/packages/delivery-service/src/rpc/rpc-proxy.test.ts
@@ -38,7 +38,7 @@ const keysA = {
 
 describe('rpc-Proxy', () => {
     describe('routing', () => {
-        it.only('Should block non-dm3 related requests', async () => {
+        it('Should block non-dm3 related requests', async () => {
             const app = express();
             app.use(bodyParser.json());
             app.use(

--- a/packages/delivery-service/src/rpc/rpc-proxy.ts
+++ b/packages/delivery-service/src/rpc/rpc-proxy.ts
@@ -27,7 +27,7 @@ export default (
     router.post('/', async (req, res, next) => {
         //RPC must be called with a method name
         if (req.body?.method === undefined) {
-            return res.send(400);
+            return res.sendStatus(400);
         }
 
         const { method } = req.body;

--- a/packages/delivery-service/src/rpc/rpc-proxy.ts
+++ b/packages/delivery-service/src/rpc/rpc-proxy.ts
@@ -58,25 +58,8 @@ export default (
                 );
 
             default:
-                return forwardToRpcNode(axios)(req, res, next);
+                return res.status(405).send({ error: 'Method not allowed' });
         }
     });
     return router;
 };
-
-const forwardToRpcNode =
-    (axios: Axios) =>
-    async (
-        req: express.Request,
-        res: express.Response,
-        next: express.NextFunction,
-    ) => {
-        global.logger.info('Forward method to rpc url');
-        try {
-            const data = (await axios.post(process.env.RPC as string, req.body))
-                .data;
-            res.json(data);
-        } catch (e) {
-            next(e);
-        }
-    };

--- a/packages/delivery-service/src/rpc/rpc-proxy.ts
+++ b/packages/delivery-service/src/rpc/rpc-proxy.ts
@@ -8,6 +8,7 @@ import { handleGetDeliveryServiceProperties } from './methods/handleGetDeliveryS
 import { handleResolveProfileExtension } from './methods/handleResolveProfileExtension';
 import { handleSubmitMessage } from './methods/handleSubmitMessage';
 import { IDatabase } from '../persistence/getDatabase';
+import { DeliveryServiceProfileKeys } from '@dm3-org/dm3-lib-profile';
 
 const DM3_SUBMIT_MESSAGE = 'dm3_submitMessage';
 const DM3_GET_DELIVERY_SERVICE_PROPERTIES = 'dm3_getDeliveryServiceProperties';
@@ -19,6 +20,7 @@ export default (
     io: Server,
     web3Provider: ethers.providers.JsonRpcProvider,
     db: IDatabase,
+    keys: DeliveryServiceProfileKeys,
 ) => {
     const router = express.Router();
 
@@ -39,6 +41,7 @@ export default (
                     deliveryServiceProperties,
                     web3Provider,
                     db,
+                    keys,
                 );
 
             case DM3_GET_DELIVERY_SERVICE_PROPERTIES:

--- a/packages/lib/crypto/package.json
+++ b/packages/lib/crypto/package.json
@@ -22,7 +22,7 @@
     "typescript": "^4.4.2"
   },
   "scripts": {
-    "build": "yarn tsc --declaration",
+    "build": "yarn tsc --declaration --declarationMap",
     "test": "jest --coverage --transformIgnorePatterns 'node_modules/(?!(dm3-lib-\\w*)/)'"
   },
   "files": [

--- a/packages/lib/delivery-api/package.json
+++ b/packages/lib/delivery-api/package.json
@@ -30,7 +30,7 @@
     "typescript": "^4.4.2"
   },
   "scripts": {
-    "build": "yarn tsc --declaration ",
+    "build": "yarn tsc --declaration --declarationMap",
     "test": "echo 'no tests'"
   },
   "files": [

--- a/packages/lib/delivery/package.json
+++ b/packages/lib/delivery/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "build:schema": "sh ./schemas.sh",
-    "build": "yarn build:schema && yarn tsc --declaration",
+    "build": "yarn build:schema && yarn tsc --declaration --declarationMap",
     "test": "jest --coverage --transformIgnorePatterns 'node_modules/(?!(dm3-lib-\\w*)/)'"
   },
   "files": [

--- a/packages/lib/delivery/package.json
+++ b/packages/lib/delivery/package.json
@@ -18,11 +18,13 @@
     "@dm3-org/dm3-lib-shared": "workspace:^",
     "@types/libsodium-wrappers": "^0.7.10",
     "ethers": "5.7.2",
+    "jsonwebtoken": "^9.0.2",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/data-urls": "^3.0.1",
     "@types/jest": "^28.1.1",
+    "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^16.7.13",
     "@types/nodemailer": "^6.4.9",
     "@types/uuid": "^8.3.4",

--- a/packages/lib/delivery/schemas.sh
+++ b/packages/lib/delivery/schemas.sh
@@ -1,5 +1,4 @@
 yarn ts-json-schema-generator -f tsconfig.json --path Delivery.ts --type DeliveryServiceProperties -o ./src/schema/DeliveryServiceProperties.schema.json --no-type-check \
 && yarn ts-json-schema-generator -f tsconfig.json --path Messages.ts --type Acknoledgment -o ./src/schema/Acknoledgment.schema.json --no-type-check \
-&& yarn ts-json-schema-generator -f tsconfig.json --path Messages.ts --type MessageSubmission -o ./src/schema/MessageSubmission.schema.json --no-type-check \
 && yarn ts-json-schema-generator -f tsconfig.json --path Session.ts --type Session -o ./src/schema/Session.schema.json --no-type-check \
 && yarn ts-json-schema-generator -f tsconfig.json --path notifications/types.ts --type NotificationChannel -o ./src/schema/NotificationChannel.schema.json --no-type-check \

--- a/packages/lib/delivery/src/Keys.test.ts
+++ b/packages/lib/delivery/src/Keys.test.ts
@@ -3,6 +3,7 @@ import { Session } from './Session';
 
 const RANDO_ADDRESS = '0xDd36ae7F9a8E34FACf1e110c6e9d37D0dc917855';
 const SENDER_ADDRESS = '0x71CB05EE1b1F506fF321Da3dac38f25c0c9ce6E1';
+const SERVER_SECRET = 'my-secret-for-jwt';
 
 const keysA = {
     encryptionKeyPair: {
@@ -67,6 +68,7 @@ describe('Keys', () => {
                     setSession,
                     '',
                     RANDO_ADDRESS,
+                    SERVER_SECRET,
                 );
             }).rejects.toEqual(Error('Session not found'));
         });
@@ -80,6 +82,7 @@ describe('Keys', () => {
                     setSession,
                     '',
                     RANDO_ADDRESS,
+                    SERVER_SECRET,
                 );
             }).rejects.toEqual(Error('No pending challenge'));
         });
@@ -108,6 +111,7 @@ describe('Keys', () => {
                 setSession,
                 signature,
                 SENDER_ADDRESS,
+                SERVER_SECRET,
             );
 
             expect(token).not.toBeUndefined();
@@ -138,6 +142,7 @@ describe('Keys', () => {
                     setSession,
                     signature,
                     SENDER_ADDRESS,
+                    SERVER_SECRET,
                 );
             }).rejects.toEqual(Error('Signature invalid'));
         });

--- a/packages/lib/delivery/src/Keys.ts
+++ b/packages/lib/delivery/src/Keys.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Session } from './Session';
 import { checkSignature } from '@dm3-org/dm3-lib-crypto';
 import { normalizeEnsName } from '@dm3-org/dm3-lib-profile';
+import { sign } from 'jsonwebtoken';
 
 export async function createChallenge(
     getSession: (accountAddress: string) => Promise<Session | null>,
@@ -23,11 +24,33 @@ export async function createChallenge(
     return challenge;
 }
 
+/**
+ * Creates a JWT that can be used to authenticate the user with the given ens name
+ * Resources:
+ *  https://jwt.io/
+ *  https://www.npmjs.com/package/jsonwebtoken
+ * @param ensName ens id of the user
+ * @param serverSecret secret value that is used to sign the JWT
+ * @param validFor time in seconds the JWT is valid for, defaults to 1 hour
+ * @returns JWT
+ */
+function generateJWT(
+    ensName: string,
+    serverSecret: string,
+    validFor: number = 60 * 60,
+) {
+    return sign(
+        { user: ensName, exp: Math.floor(Date.now() / 1000) + validFor },
+        serverSecret,
+    );
+}
+
 export async function createNewSessionToken(
     getSession: (ensName: string) => Promise<Session | null>,
     setSession: (ensName: string, session: Session) => Promise<void>,
     signature: string,
     ensName: string,
+    serverSecret: string,
 ): Promise<string> {
     const session = await getSession(ensName);
 
@@ -40,6 +63,7 @@ export async function createNewSessionToken(
     }
 
     if (
+        // todo: get public signing key from public profile
         !(await checkSignature(
             session.signedUserProfile.profile.publicSigningKey,
             session.challenge,
@@ -49,7 +73,9 @@ export async function createNewSessionToken(
         throw Error('Signature invalid');
     }
 
-    const token = uuidv4();
-    await setSession(ensName, { ...session, challenge: undefined, token });
-    return token;
+    // todo: create jwt instead, which does not have to be stored in the session
+    const jwt = generateJWT(ensName, serverSecret);
+    // todo: remove challenge from session
+    await setSession(ensName, { ...session, challenge: undefined, token: jwt });
+    return jwt;
 }

--- a/packages/lib/delivery/src/Messages.test.ts
+++ b/packages/lib/delivery/src/Messages.test.ts
@@ -1,5 +1,5 @@
 import { checkSignature, decryptAsymmetric } from '@dm3-org/dm3-lib-crypto';
-import { EncryptionEnvelop } from '@dm3-org/dm3-lib-messaging';
+import { EncryptionEnvelop, Postmark } from '@dm3-org/dm3-lib-messaging';
 import { UserProfile, normalizeEnsName } from '@dm3-org/dm3-lib-profile';
 import { sha256 } from '@dm3-org/dm3-lib-shared';
 import { BigNumber, ethers } from 'ethers';
@@ -7,13 +7,11 @@ import { testData } from '../../../../test-data/encrypted-envelops.test';
 import { stringify } from '../../shared/src/stringify';
 import { getConversationId, getMessages, incomingMessage } from './Messages';
 import { Session } from './Session';
-import { SpamFilterRules } from './spam-filter/SpamFilterRules';
-import { Postmark } from '@dm3-org/dm3-lib-messaging';
 import {
     NotificationChannel,
     NotificationChannelType,
 } from './notifications/types';
-import { sign } from 'crypto';
+import { SpamFilterRules } from './spam-filter/SpamFilterRules';
 
 const SENDER_NAME = 'alice.eth';
 const RECEIVER_NAME = 'bob.eth';

--- a/packages/lib/delivery/src/Messages.test.ts
+++ b/packages/lib/delivery/src/Messages.test.ts
@@ -116,7 +116,7 @@ describe('Messages', () => {
         writable: true,
     });
     describe('incomingMessage', () => {
-        it('rejctes an incoming message if the token is not valid', async () => {
+        it('accepts an incoming message', async () => {
             const storeNewMessage = async (
                 conversationId: string,
                 envelop: EncryptionEnvelop,
@@ -127,20 +127,18 @@ describe('Messages', () => {
             await expect(() =>
                 incomingMessage(
                     {
-                        envelop: {
-                            message: '',
-                            metadata: {
-                                version: '',
-                                encryptionScheme: 'x25519-chacha20-poly1305',
-                                deliveryInformation: stringify(
-                                    testData.deliveryInformation,
-                                ),
-                                encryptedMessageHash: '',
-                                signature: '',
-                            },
+                        message: '',
+                        metadata: {
+                            version: '',
+                            encryptionScheme: 'x25519-chacha20-poly1305',
+                            deliveryInformation: stringify(
+                                testData.deliveryInformation,
+                            ),
+                            encryptedMessageHash: '',
+                            signature: '',
                         },
-                        token: 'abc',
                     },
+
                     keysA.signingKeyPair,
                     keysA.encryptionKeyPair,
                     2 ** 14,
@@ -155,7 +153,7 @@ describe('Messages', () => {
                     async () => '',
                     getNotificationChannels,
                 ),
-            ).rejects.toEqual(Error('Token check failed'));
+            ).not.toThrow();
         });
 
         it('rejects an incoming message if it is to large', async () => {
@@ -169,17 +167,14 @@ describe('Messages', () => {
             await expect(() =>
                 incomingMessage(
                     {
-                        envelop: {
-                            metadata: {
-                                encryptionScheme: 'x25519-chacha20-poly1305',
-                                deliveryInformation: '',
-                                encryptedMessageHash: '',
-                                signature: '',
-                                version: '',
-                            },
-                            message: '',
+                        metadata: {
+                            encryptionScheme: 'x25519-chacha20-poly1305',
+                            deliveryInformation: '',
+                            encryptedMessageHash: '',
+                            signature: '',
+                            version: '',
                         },
-                        token: '123',
+                        message: '',
                     },
                     keysA.signingKeyPair,
                     keysA.encryptionKeyPair,
@@ -205,19 +200,16 @@ describe('Messages', () => {
             await expect(() =>
                 incomingMessage(
                     {
-                        envelop: {
-                            message: '',
-                            metadata: {
-                                encryptionScheme: 'x25519-chacha20-poly1305',
-                                version: '',
-                                encryptedMessageHash: '',
-                                signature: '',
-                                deliveryInformation: stringify(
-                                    testData.deliveryInformationB,
-                                ),
-                            },
+                        message: '',
+                        metadata: {
+                            encryptionScheme: 'x25519-chacha20-poly1305',
+                            version: '',
+                            encryptedMessageHash: '',
+                            signature: '',
+                            deliveryInformation: stringify(
+                                testData.deliveryInformationB,
+                            ),
                         },
-                        token: '123',
                     },
                     keysA.signingKeyPair,
                     keysA.encryptionKeyPair,
@@ -267,19 +259,16 @@ describe('Messages', () => {
             try {
                 await incomingMessage(
                     {
-                        envelop: {
-                            message: '',
-                            metadata: {
-                                encryptionScheme: 'x25519-chacha20-poly1305',
-                                encryptedMessageHash: '',
-                                signature: '',
-                                version: '',
-                                deliveryInformation: stringify(
-                                    testData.deliveryInformation,
-                                ),
-                            },
+                        message: '',
+                        metadata: {
+                            encryptionScheme: 'x25519-chacha20-poly1305',
+                            encryptedMessageHash: '',
+                            signature: '',
+                            version: '',
+                            deliveryInformation: stringify(
+                                testData.deliveryInformation,
+                            ),
                         },
-                        token: '123',
                     },
                     keysA.signingKeyPair,
                     keysA.encryptionKeyPair,
@@ -331,19 +320,16 @@ describe('Messages', () => {
             try {
                 await incomingMessage(
                     {
-                        envelop: {
-                            message: '',
-                            metadata: {
-                                encryptionScheme: 'x25519-chacha20-poly1305',
-                                version: '',
-                                encryptedMessageHash: '',
-                                signature: '',
-                                deliveryInformation: stringify(
-                                    testData.deliveryInformation,
-                                ),
-                            },
+                        message: '',
+                        metadata: {
+                            encryptionScheme: 'x25519-chacha20-poly1305',
+                            version: '',
+                            encryptedMessageHash: '',
+                            signature: '',
+                            deliveryInformation: stringify(
+                                testData.deliveryInformation,
+                            ),
                         },
-                        token: '123',
                     },
                     keysA.signingKeyPair,
                     keysA.encryptionKeyPair,
@@ -402,20 +388,17 @@ describe('Messages', () => {
             try {
                 await incomingMessage(
                     {
-                        envelop: {
-                            message: '',
-                            metadata: {
-                                encryptionScheme: 'x25519-chacha20-poly1305',
-                                deliveryInformation: stringify(
-                                    testData.deliveryInformation,
-                                ),
+                        message: '',
+                        metadata: {
+                            encryptionScheme: 'x25519-chacha20-poly1305',
+                            deliveryInformation: stringify(
+                                testData.deliveryInformation,
+                            ),
 
-                                version: '',
-                                encryptedMessageHash: '',
-                                signature: '',
-                            },
+                            version: '',
+                            encryptedMessageHash: '',
+                            signature: '',
                         },
-                        token: '123',
                     },
                     keysA.signingKeyPair,
                     keysA.encryptionKeyPair,
@@ -480,19 +463,16 @@ describe('Messages', () => {
 
             await incomingMessage(
                 {
-                    envelop: {
-                        message: '',
-                        metadata: {
-                            version: '',
-                            encryptedMessageHash: '',
-                            signature: '',
-                            encryptionScheme: 'x25519-chacha20-poly1305',
-                            deliveryInformation: stringify(
-                                testData.deliveryInformation,
-                            ),
-                        },
+                    message: '',
+                    metadata: {
+                        version: '',
+                        encryptedMessageHash: '',
+                        signature: '',
+                        encryptionScheme: 'x25519-chacha20-poly1305',
+                        deliveryInformation: stringify(
+                            testData.deliveryInformation,
+                        ),
                     },
-                    token: '123',
                 },
                 keysA.signingKeyPair,
                 keysA.encryptionKeyPair,
@@ -536,19 +516,16 @@ describe('Messages', () => {
 
             await incomingMessage(
                 {
-                    envelop: {
-                        message: '',
-                        metadata: {
-                            version: '',
-                            encryptedMessageHash: '',
-                            signature: '',
-                            encryptionScheme: 'x25519-chacha20-poly1305',
-                            deliveryInformation: stringify(
-                                testData.deliveryInformation,
-                            ),
-                        },
+                    message: '',
+                    metadata: {
+                        version: '',
+                        encryptedMessageHash: '',
+                        signature: '',
+                        encryptionScheme: 'x25519-chacha20-poly1305',
+                        deliveryInformation: stringify(
+                            testData.deliveryInformation,
+                        ),
                     },
-                    token: '123',
                 },
                 keysA.signingKeyPair,
                 keysA.encryptionKeyPair,
@@ -625,19 +602,16 @@ describe('Messages', () => {
 
             await incomingMessage(
                 {
-                    envelop: {
-                        message: '',
-                        metadata: {
-                            encryptionScheme: 'x25519-chacha20-poly1305',
-                            deliveryInformation: stringify(
-                                testData.deliveryInformation,
-                            ),
-                            version: '',
-                            encryptedMessageHash: '',
-                            signature: '',
-                        },
+                    message: '',
+                    metadata: {
+                        encryptionScheme: 'x25519-chacha20-poly1305',
+                        deliveryInformation: stringify(
+                            testData.deliveryInformation,
+                        ),
+                        version: '',
+                        encryptedMessageHash: '',
+                        signature: '',
                     },
-                    token: '123',
                 },
                 keysA.signingKeyPair,
                 keysA.encryptionKeyPair,

--- a/packages/lib/delivery/src/Messages.test.ts
+++ b/packages/lib/delivery/src/Messages.test.ts
@@ -110,6 +110,11 @@ nodemailer.createTransport.mockReturnValue({
 });
 
 describe('Messages', () => {
+    // fixes tests with fake timers failing locally (at least for malteish), see
+    // https://stackoverflow.com/questions/77694957/typeerror-cannot-assign-to-read-only-property-performance-of-object-object
+    Object.defineProperty(global, 'performance', {
+        writable: true,
+    });
     describe('incomingMessage', () => {
         it('rejctes an incoming message if the token is not valid', async () => {
             const storeNewMessage = async (

--- a/packages/lib/delivery/src/Messages.ts
+++ b/packages/lib/delivery/src/Messages.ts
@@ -111,7 +111,7 @@ export async function incomingMessage(
         throw Error('Message is too large');
     }
 
-    //Decryptes the encrypted DeliveryInformation with the KeyPair of the deliveryService
+    //Decrypts the encrypted DeliveryInformation with the KeyPair of the deliveryService
 
     const deliveryInformation: DeliveryInformation =
         await decryptDeliveryInformation(envelop, encryptionKeyPair);

--- a/packages/lib/delivery/src/Messages.ts
+++ b/packages/lib/delivery/src/Messages.ts
@@ -138,7 +138,7 @@ export async function incomingMessage(
         receiverSession,
     });
 
-    //Checkes if the message is spam
+    //Checks if the message is spam
     if (await isSpam(provider, receiverSession, deliveryInformation)) {
         logDebug({
             text: 'incomingMessage is spam',

--- a/packages/lib/delivery/src/Session.test.ts
+++ b/packages/lib/delivery/src/Session.test.ts
@@ -1,11 +1,18 @@
 import { checkToken, Session } from './Session';
+import { sign } from 'jsonwebtoken';
+
+const serverSecret = 'veryImportantSecretToGenerateAndValidateJSONWebTokens';
+// create valid jwt
+const token = sign({ user: 'alice.eth' }, serverSecret, {
+    expiresIn: '1h',
+});
 
 describe('Session', () => {
     describe('checkToken', () => {
-        it('Should return true if a session exists for this account', async () => {
+        it('Should return true if the jwt is valid', async () => {
             const getSession = (_: string) =>
                 Promise.resolve({
-                    token: 'foo',
+                    token: token,
                     createdAt: new Date().getTime(),
                 } as Session);
 
@@ -16,7 +23,8 @@ describe('Session', () => {
                 } as any,
                 getSession,
                 'alice.eth',
-                'foo',
+                token,
+                serverSecret,
             );
 
             expect(isValid).toBe(true);
@@ -32,13 +40,17 @@ describe('Session', () => {
                 } as any,
                 getSession,
                 'alice.eth',
-                'foo',
+                token,
+                serverSecret,
             );
 
             expect(isValid).toBe(false);
         });
 
-        it('Should return false if a session exists but the token is wrong ', async () => {
+        it('Should return false if the token is signed with a different secret ', async () => {
+            const token = sign({ user: 'alice.eth' }, 'attackersSecret', {
+                expiresIn: '1h',
+            });
             const getSession = (_: string) =>
                 Promise.resolve({ token: 'bar' } as Session);
 
@@ -49,7 +61,8 @@ describe('Session', () => {
                 } as any,
                 getSession,
                 'alice.eth',
-                'foo',
+                token,
+                serverSecret,
             );
 
             expect(isValid).toBe(false);
@@ -57,7 +70,14 @@ describe('Session', () => {
 
         it('Should return false if a session exists but the token is expired ', async () => {
             const getSession = (_: string) =>
-                Promise.resolve({ token: 'foo', createdAt: 1 } as Session);
+                Promise.resolve({ token: token, createdAt: 1 } as Session);
+
+            const oneMinuteAgo = new Date().getTime() / 1000 - 60;
+            // this token expired a minute ago
+            const _token = sign(
+                { user: 'alice.eth', iat: oneMinuteAgo, exp: oneMinuteAgo },
+                serverSecret,
+            );
 
             const isValid = await checkToken(
                 {
@@ -66,7 +86,37 @@ describe('Session', () => {
                 } as any,
                 getSession,
                 'alice.eth',
-                'foo',
+                _token,
+                serverSecret,
+            );
+
+            expect(isValid).toBe(false);
+        });
+
+        it('Should return false token issuance date is in the future ', async () => {
+            const getSession = (_: string) =>
+                Promise.resolve({ token: token, createdAt: 1 } as Session);
+
+            const oneMinuteInTheFuture = new Date().getTime() / 1000 + 60;
+            // this token is not valid yet
+            const _token = sign(
+                {
+                    user: 'alice.eth',
+                    iat: oneMinuteInTheFuture,
+                    exp: oneMinuteInTheFuture,
+                },
+                serverSecret,
+            );
+
+            const isValid = await checkToken(
+                {
+                    resolveName: async () =>
+                        '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
+                } as any,
+                getSession,
+                'alice.eth',
+                _token,
+                serverSecret,
             );
 
             expect(isValid).toBe(false);

--- a/packages/lib/delivery/src/Session.ts
+++ b/packages/lib/delivery/src/Session.ts
@@ -76,6 +76,13 @@ export async function checkToken(
             return false;
         }
 
+        if (!jwtPayload.iat || jwtPayload.iat > Date.now() / 1000) {
+            logDebug({
+                text: `jwt invalid: iat missing or in the future`,
+            });
+            return false;
+        }
+
         if (jwtPayload.user !== ensName) {
             logDebug({
                 text: `jwt invalid: user mismatch`,

--- a/packages/lib/delivery/src/Session.ts
+++ b/packages/lib/delivery/src/Session.ts
@@ -65,7 +65,11 @@ export async function checkToken(
         }
 
         // check if expected fields are present
-        if (!('user' in jwtPayload)) {
+        if (
+            !('user' in jwtPayload) ||
+            !('iat' in jwtPayload) ||
+            !('exp' in jwtPayload)
+        ) {
             logDebug({
                 text: `jwt invalid: user missing`,
             });
@@ -75,13 +79,6 @@ export async function checkToken(
         if (jwtPayload.user !== ensName) {
             logDebug({
                 text: `jwt invalid: user mismatch`,
-            });
-            return false;
-        }
-
-        if (!jwtPayload.iat || jwtPayload.iat > Date.now() / 1000) {
-            logDebug({
-                text: `jwt invalid: iat missing or in the future`,
             });
             return false;
         }

--- a/packages/lib/delivery/src/UserProfile.ts
+++ b/packages/lib/delivery/src/UserProfile.ts
@@ -44,7 +44,7 @@ export async function submitUserProfile(
         logDebug('submitUserProfile - Signature invalid');
         throw Error('Signature invalid.');
     }
-    //TODO:  remvoe DISABLE_SESSION_CHECK
+    //TODO:  remove DISABLE_SESSION_CHECK
     // DISABLE_SESSION_CHECK is a special solution for ETH Prague
     if (
         process.env.DISABLE_SESSION_CHECK !== 'true' &&

--- a/packages/lib/delivery/src/schema/index.ts
+++ b/packages/lib/delivery/src/schema/index.ts
@@ -1,12 +1,9 @@
 import AcknoledgmentSchema from './Acknoledgment.schema.json';
 import DeliveryServicePropertiesSchema from './DeliveryServiceProperties.schema.json';
-import MessageSubmissionSchema from './MessageSubmission.schema.json';
 import SessionSchema from './Session.schema.json';
 import NotificationChannelSchema from './NotificationChannel.schema.json';
 
 export const Acknoledgment = AcknoledgmentSchema.definitions.Acknoledgment;
 export const DeliveryServiceProperties = DeliveryServicePropertiesSchema;
-export const MessageSubmission = MessageSubmissionSchema;
 export const Session = SessionSchema;
 export const NotificationChannel = NotificationChannelSchema;
-export const EncryptionEnvelop = EncryptionEnvelopSchema;

--- a/packages/lib/delivery/src/schema/index.ts
+++ b/packages/lib/delivery/src/schema/index.ts
@@ -9,3 +9,4 @@ export const DeliveryServiceProperties = DeliveryServicePropertiesSchema;
 export const MessageSubmission = MessageSubmissionSchema;
 export const Session = SessionSchema;
 export const NotificationChannel = NotificationChannelSchema;
+export const EncryptionEnvelop = EncryptionEnvelopSchema;

--- a/packages/lib/messaging/package.json
+++ b/packages/lib/messaging/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build:schema": "sh ./schemas.sh",
-    "build": "yarn build:schema &&yarn tsc --declaration",
+    "build": "yarn build:schema &&yarn tsc --declaration  --declarationMap",
     "test": "jest --coverage --transformIgnorePatterns 'node_modules/(?!(dm3-lib-\\w*)/)'"
   },
   "files": [

--- a/packages/lib/offchainResolver-api/package.json
+++ b/packages/lib/offchainResolver-api/package.json
@@ -28,7 +28,7 @@
     "typescript": "^4.7.0"
   },
   "scripts": {
-    "build": "yarn tsc --declaration ",
+    "build": "yarn tsc --declaration  --declarationMap",
     "test": "echo 'no tests'"
   },
   "files": [

--- a/packages/lib/profile/package.json
+++ b/packages/lib/profile/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "build:schema": "sh ./schemas.sh",
-    "build": "yarn build:schema && yarn tsc --declaration ",
+    "build": "yarn build:schema && yarn tsc --declaration  --declarationMap",
     "test": "jest --coverage --transformIgnorePatterns 'node_modules/(?!(dm3-lib-\\w*)/)'"
   },
   "files": [

--- a/packages/lib/server-side/jest.config.js
+++ b/packages/lib/server-side/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+    preset: 'ts-jest/presets/js-with-ts',
+    testEnvironment: 'node',
+    modulePathIgnorePatterns: ['./dist'],
+};

--- a/packages/lib/server-side/package.json
+++ b/packages/lib/server-side/package.json
@@ -22,7 +22,7 @@
     "typescript": "^4.4.2"
   },
   "scripts": {
-    "build": "yarn tsc --declaration",
+    "build": "yarn tsc --declaration  --declarationMap",
     "test": "jest --coverage"
   },
   "files": [

--- a/packages/lib/server-side/package.json
+++ b/packages/lib/server-side/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "yarn tsc --declaration",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "files": [
     "dist"

--- a/packages/lib/server-side/package.json
+++ b/packages/lib/server-side/package.json
@@ -17,11 +17,13 @@
     "express": "^4.18.1"
   },
   "devDependencies": {
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
     "typescript": "^4.4.2"
   },
   "scripts": {
     "build": "yarn tsc --declaration",
-    "test": "echo 'no tests'"
+    "test": "jest"
   },
   "files": [
     "dist"

--- a/packages/lib/server-side/src/auth.test.ts
+++ b/packages/lib/server-side/src/auth.test.ts
@@ -4,6 +4,8 @@ import express from 'express';
 import request from 'supertest';
 import { Auth } from './auth';
 
+const serverSecret = 'testSecret';
+
 describe('Auth', () => {
     const getSessionMock = async (ensName: string) =>
         Promise.resolve({ challenge: '123' });
@@ -30,7 +32,7 @@ describe('Auth', () => {
             it('Returns 200 if schema is valid', async () => {
                 const app = express();
                 app.use(bodyParser.json());
-                app.use(Auth(getSessionMock, setSessionMock));
+                app.use(Auth(getSessionMock, setSessionMock, serverSecret));
 
                 const response = await request(app)
                     .get(
@@ -49,7 +51,7 @@ describe('Auth', () => {
             it('Returns 400 if params is invalid', async () => {
                 const app = express();
                 app.use(bodyParser.json());
-                app.use(Auth(getSessionMock, setSessionMock));
+                app.use(Auth(getSessionMock, setSessionMock, serverSecret));
 
                 const mnemonic =
                     'announce room limb pattern dry unit scale effort smooth jazz weasel alcohol';
@@ -67,7 +69,7 @@ describe('Auth', () => {
             it('Returns 400 if body is invalid', async () => {
                 const app = express();
                 app.use(bodyParser.json());
-                app.use(Auth(getSessionMock, setSessionMock));
+                app.use(Auth(getSessionMock, setSessionMock, serverSecret));
 
                 const mnemonic =
                     'announce room limb pattern dry unit scale effort smooth jazz weasel alcohol';
@@ -96,7 +98,9 @@ describe('Auth', () => {
 
                 const app = express();
                 app.use(bodyParser.json());
-                app.use(Auth(getSessionMockLocal, setSessionMock));
+                app.use(
+                    Auth(getSessionMockLocal, setSessionMock, serverSecret),
+                );
 
                 const signature =
                     '3A893rTBPEa3g9FL2vgDreY3vvXnOiYCOoJURNyctncwH' +

--- a/packages/lib/server-side/src/auth.test.ts
+++ b/packages/lib/server-side/src/auth.test.ts
@@ -1,13 +1,8 @@
 import bodyParser from 'body-parser';
+import { ethers } from 'ethers';
 import express from 'express';
 import request from 'supertest';
 import { Auth } from './auth';
-import { ethers } from 'ethers';
-import winston from 'winston';
-
-// global.logger = winston.createLogger({
-//     transports: [new winston.transports.Console()],
-// });
 
 describe('Auth', () => {
     const getSessionMock = async (ensName: string) =>

--- a/packages/lib/server-side/src/auth.ts
+++ b/packages/lib/server-side/src/auth.ts
@@ -39,6 +39,9 @@ const createNewSessionTokenBodySchema = {
 export const Auth = (getSession, setSession) => {
     const router = express.Router();
 
+    // todo: inject secret
+    const serverSecret = 'secret81759';
+
     //TODO remove
     router.use(cors());
 
@@ -69,43 +72,38 @@ export const Auth = (getSession, setSession) => {
         }
     });
 
-    router.post(
-        '/:ensName',
-        //@ts-ignore
-        async (req: express.Request, res, next) => {
-            try {
-                const idEnsName = await normalizeEnsName(req.params.ensName);
-                const paramsAreValid = validateSchema(
-                    createNewSessionTokenParamsSchema,
-                    req.params,
-                );
+    router.post('/:ensName', async (req: express.Request, res, next) => {
+        try {
+            const idEnsName = await normalizeEnsName(req.params.ensName);
+            const paramsAreValid = validateSchema(
+                createNewSessionTokenParamsSchema,
+                req.params,
+            );
 
-                const bodyIsValid = validateSchema(
-                    createNewSessionTokenBodySchema,
-                    req.body,
-                );
+            const bodyIsValid = validateSchema(
+                createNewSessionTokenBodySchema,
+                req.body,
+            );
 
-                const schemaIsValid = paramsAreValid && bodyIsValid;
+            const schemaIsValid = paramsAreValid && bodyIsValid;
 
-                if (!schemaIsValid) {
-                    return res.send(400);
-                }
-
-                const token = await createNewSessionToken(
-                    getSession,
-                    setSession,
-                    req.body.signature,
-                    idEnsName,
-                );
-
-                res.json({
-                    token,
-                });
-            } catch (e) {
-                next(e);
+            if (!schemaIsValid) {
+                return res.send(400);
             }
-        },
-    );
+
+            const jwt = await createNewSessionToken(
+                getSession,
+                setSession,
+                req.body.signature,
+                idEnsName,
+                serverSecret,
+            );
+
+            res.json(jwt);
+        } catch (e) {
+            next(e);
+        }
+    });
 
     return router;
 };

--- a/packages/lib/server-side/src/auth.ts
+++ b/packages/lib/server-side/src/auth.ts
@@ -42,41 +42,37 @@ export const Auth = (getSession, setSession) => {
     //TODO remove
     router.use(cors());
 
-    router.get(
-        '/:ensName',
-        //@ts-ignore
-        async (req: express.Request & { app: WithLocals }, res, next) => {
-            try {
-                const idEnsName = await normalizeEnsName(req.params.ensName);
+    router.get('/:ensName', async (req: express.Request, res, next) => {
+        try {
+            const idEnsName = normalizeEnsName(req.params.ensName);
 
-                const schemaIsValid = validateSchema(
-                    getChallengeSchema,
-                    req.params,
-                );
+            const schemaIsValid = validateSchema(
+                getChallengeSchema,
+                req.params,
+            );
 
-                if (!schemaIsValid) {
-                    return res.send(400);
-                }
-
-                const challenge = await createChallenge(
-                    getSession,
-                    setSession,
-                    idEnsName,
-                );
-
-                res.json({
-                    challenge,
-                });
-            } catch (e) {
-                next(e);
+            if (!schemaIsValid) {
+                return res.send(400);
             }
-        },
-    );
+
+            const challenge = await createChallenge(
+                getSession,
+                setSession,
+                idEnsName,
+            );
+
+            res.json({
+                challenge,
+            });
+        } catch (e) {
+            next(e);
+        }
+    });
 
     router.post(
         '/:ensName',
         //@ts-ignore
-        async (req: express.Request & { app: WithLocals }, res, next) => {
+        async (req: express.Request, res, next) => {
             try {
                 const idEnsName = await normalizeEnsName(req.params.ensName);
                 const paramsAreValid = validateSchema(

--- a/packages/lib/server-side/src/auth.ts
+++ b/packages/lib/server-side/src/auth.ts
@@ -36,11 +36,8 @@ const createNewSessionTokenBodySchema = {
 };
 
 //@ts-ignore
-export const Auth = (getSession, setSession) => {
+export const Auth = (getSession, setSession, serverSecret: string) => {
     const router = express.Router();
-
-    // todo: inject secret
-    const serverSecret = 'secret81759';
 
     //TODO remove
     router.use(cors());

--- a/packages/lib/server-side/src/utils.test.ts
+++ b/packages/lib/server-side/src/utils.test.ts
@@ -2,70 +2,109 @@ import bodyParser from 'body-parser';
 import express from 'express';
 import { auth } from './utils';
 import request from 'supertest';
-import winston from 'winston';
-
-global.logger = winston.createLogger({
-    transports: [new winston.transports.Console()],
-});
+import { NextFunction, Request, Response } from 'express';
+import { ISessionDatabase } from './iSessionDatabase';
 
 describe('Utils', () => {
     describe('Auth', () => {
         it('Returns 200 if token is valid', async () => {
+            const getSession = async (accountAddress: string) =>
+                Promise.resolve({
+                    signedUserProfile: {},
+                    token: 'testToken',
+                    createdAt: new Date().getTime(),
+                });
+            const setSession = async (_: string, __: any) => {
+                return (_: any, __: any, ___: any) => {};
+            };
+
+            const db = {
+                getSession,
+                setSession,
+            };
+
+            const web3Provider = {
+                resolveName: async () =>
+                    '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
+            };
+
             const app = express();
             const router = express.Router();
             app.use(bodyParser.json());
             app.use(router);
-            router.param('address', auth);
+            router.param(
+                'address',
+                async (
+                    req: Request,
+                    res: Response,
+                    next: NextFunction,
+                    ensName: string,
+                ) => {
+                    auth(
+                        req,
+                        res,
+                        next,
+                        ensName,
+                        db as any,
+                        web3Provider as any,
+                    );
+                },
+            );
 
             //Mock request auth protected
             router.get('/:address', (req, res) => {
                 return res.send(200);
             });
 
-            app.locals.db = {
-                getSession: async (accountAddress: string) =>
-                    Promise.resolve({
-                        signedUserProfile: {},
-                        token: 'foo',
-                        createdAt: new Date().getTime(),
-                    }),
-                setSession: async (_: string, __: any) => {
-                    return (_: any, __: any, ___: any) => {};
-                },
-            };
-
-            app.locals.web3Provider = {
-                resolveName: async () =>
-                    '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
-            };
-
             const { status, body } = await request(app)
                 .get('/alice.eth')
-                .set({ authorization: `Bearer foo` })
+                .set({ authorization: `Bearer testToken` })
 
                 .send();
 
             expect(status).toBe(200);
         });
         it('Returns 401 if user is unknown', async () => {
-            const app = express();
-            const router = express.Router();
-            app.use(bodyParser.json());
-            app.use(router);
-            router.param('address', auth);
-
-            //Mock request auth protected
-            router.get('/:address', (req, res) => {
-                return res.send(200);
-            });
-
-            app.locals.db = {
+            const db = {
                 getSession: async (accountAddress: string) =>
                     Promise.resolve(null),
                 setSession: async (_: string, __: any) => {
                     return (_: any, __: any, ___: any) => {};
                 },
             };
+
+            const web3Provider = {
+                resolveName: async () =>
+                    '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
+            };
+
+            const app = express();
+            const router = express.Router();
+            app.use(bodyParser.json());
+            app.use(router);
+            router.param(
+                'address',
+                async (
+                    req: Request,
+                    res: Response,
+                    next: NextFunction,
+                    ensName: string,
+                ) => {
+                    auth(
+                        req,
+                        res,
+                        next,
+                        ensName,
+                        db as any,
+                        web3Provider as any,
+                    );
+                },
+            );
+
+            //Mock request auth protected
+            router.get('/:address', (req, res) => {
+                return res.send(200);
+            });
 
             app.locals.web3Provider = {
                 resolveName: async () =>
@@ -85,18 +124,7 @@ describe('Utils', () => {
             expect(status).toBe(401);
         });
         it('Returns 401 if token is invalid', async () => {
-            const app = express();
-            const router = express.Router();
-            app.use(bodyParser.json());
-            app.use(router);
-            router.param('address', auth);
-
-            //Mock request auth protected
-            router.get('/:address', (req, res) => {
-                return res.send(200);
-            });
-
-            app.locals.db = {
+            const db = {
                 getSession: async (accountAddress: string) =>
                     Promise.resolve({
                         signedUserProfile: {},
@@ -107,14 +135,38 @@ describe('Utils', () => {
                 },
             };
 
-            app.locals.web3Provider = {
+            const web3Provider = {
                 resolveName: async () =>
                     '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
             };
 
-            app.locals.logger = {
-                warn: (_: string) => {},
-            };
+            const app = express();
+            const router = express.Router();
+            app.use(bodyParser.json());
+            app.use(router);
+            router.param(
+                'address',
+                async (
+                    req: Request,
+                    res: Response,
+                    next: NextFunction,
+                    ensName: string,
+                ) => {
+                    auth(
+                        req,
+                        res,
+                        next,
+                        ensName,
+                        db as any,
+                        web3Provider as any,
+                    );
+                },
+            );
+
+            //Mock request auth protected
+            router.get('/:address', (req, res) => {
+                return res.send(200);
+            });
 
             const { status, body } = await request(app)
                 .get('/0x25A643B6e52864d0eD816F1E43c0CF49C83B8292')
@@ -125,18 +177,7 @@ describe('Utils', () => {
             expect(status).toBe(401);
         });
         it('Returns 401 if token is expired', async () => {
-            const app = express();
-            const router = express.Router();
-            app.use(bodyParser.json());
-            app.use(router);
-            router.param('address', auth);
-
-            //Mock request auth protected
-            router.get('/:address', (req, res) => {
-                return res.send(200);
-            });
-
-            app.locals.db = {
+            const db = {
                 getSession: async (accountAddress: string) =>
                     Promise.resolve({
                         signedUserProfile: {},
@@ -148,14 +189,38 @@ describe('Utils', () => {
                 },
             };
 
-            app.locals.web3Provider = {
+            const web3Provider = {
                 resolveName: async () =>
                     '0x25A643B6e52864d0eD816F1E43c0CF49C83B8292',
             };
 
-            app.locals.logger = {
-                warn: (_: string) => {},
-            };
+            const app = express();
+            const router = express.Router();
+            app.use(bodyParser.json());
+            app.use(router);
+            router.param(
+                'address',
+                async (
+                    req: Request,
+                    res: Response,
+                    next: NextFunction,
+                    ensName: string,
+                ) => {
+                    auth(
+                        req,
+                        res,
+                        next,
+                        ensName,
+                        db as any,
+                        web3Provider as any,
+                    );
+                },
+            );
+
+            //Mock request auth protected
+            router.get('/:address', (req, res) => {
+                return res.send(200);
+            });
 
             const { status, body } = await request(app)
                 .get('/0x25A643B6e52864d0eD816F1E43c0CF49C83B8292')

--- a/packages/lib/server-side/src/utils.test.ts
+++ b/packages/lib/server-side/src/utils.test.ts
@@ -1,9 +1,7 @@
 import bodyParser from 'body-parser';
-import express from 'express';
-import { auth } from './utils';
+import express, { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
-import { NextFunction, Request, Response } from 'express';
-import { ISessionDatabase } from './iSessionDatabase';
+import { auth } from './utils';
 
 describe('Utils', () => {
     describe('Auth', () => {

--- a/packages/lib/server-side/src/utils.ts
+++ b/packages/lib/server-side/src/utils.ts
@@ -5,7 +5,10 @@ import { Express, NextFunction, Request, Response } from 'express';
 import { Socket } from 'socket.io';
 import winston from 'winston';
 import { ExtendedError } from 'socket.io/dist/namespace';
-import { normalizeEnsName } from '@dm3-org/dm3-lib-profile';
+import {
+    DeliveryServiceProfileKeys,
+    normalizeEnsName,
+} from '@dm3-org/dm3-lib-profile';
 import { checkToken } from '@dm3-org/dm3-lib-delivery';
 import { KeyPair } from '@dm3-org/dm3-lib-crypto';
 
@@ -121,10 +124,9 @@ export function errorHandler(
     res.render('error', { error: err });
 }
 
-export function readKeysFromEnv(env: NodeJS.ProcessEnv): {
-    encryption: KeyPair;
-    signing: KeyPair;
-} {
+export function readKeysFromEnv(
+    env: NodeJS.ProcessEnv,
+): DeliveryServiceProfileKeys {
     const readKey = (keyName: string) => {
         const key = env[keyName];
         if (!key) {
@@ -135,11 +137,11 @@ export function readKeysFromEnv(env: NodeJS.ProcessEnv): {
     };
 
     return {
-        signing: {
+        signingKeyPair: {
             publicKey: readKey('SIGNING_PUBLIC_KEY'),
             privateKey: readKey('SIGNING_PRIVATE_KEY'),
         },
-        encryption: {
+        encryptionKeyPair: {
             publicKey: readKey('ENCRYPTION_PUBLIC_KEY'),
             privateKey: readKey('ENCRYPTION_PRIVATE_KEY'),
         },

--- a/packages/lib/server-side/src/utils.ts
+++ b/packages/lib/server-side/src/utils.ts
@@ -10,7 +10,6 @@ import {
     normalizeEnsName,
 } from '@dm3-org/dm3-lib-profile';
 import { checkToken } from '@dm3-org/dm3-lib-delivery';
-import { KeyPair } from '@dm3-org/dm3-lib-crypto';
 
 export async function auth(
     req: Request,

--- a/packages/lib/server-side/src/utils.ts
+++ b/packages/lib/server-side/src/utils.ts
@@ -19,6 +19,7 @@ export async function auth(
     ensName: string,
     db: ISessionDatabase,
     web3Provider: ethers.providers.JsonRpcProvider,
+    serverSecret: string,
 ) {
     const normalizedEnsName = normalizeEnsName(ensName);
     const authHeader = req.headers['authorization'];
@@ -31,6 +32,7 @@ export async function auth(
             db.getSession,
             normalizedEnsName,
             token,
+            serverSecret,
         ))
     ) {
         next();
@@ -47,6 +49,7 @@ export async function auth(
 export function socketAuth(
     db: ISessionDatabase,
     web3Provider: ethers.providers.JsonRpcProvider,
+    serverSecret: string,
 ) {
     return async (
         socket: Socket,
@@ -69,6 +72,7 @@ export function socketAuth(
                     db.getSession,
                     ensName,
                     socket.handshake.auth.token as string,
+                    serverSecret,
                 ))
             ) {
                 return next(new Error('invalid username'));
@@ -174,6 +178,15 @@ export async function getWeb3Provider(
     });
 
     // return getCachedProvider(new ethers.providers.JsonRpcProvider(rpc));
+}
+
+export function getServerSecret(env: NodeJS.ProcessEnv): string {
+    const secret = env.SERVER_SECRET;
+    if (!secret) {
+        throw Error('Missing SERVER_SECRET in env');
+    }
+
+    return secret;
 }
 
 const getCachedProvider = (

--- a/packages/lib/shared/package.json
+++ b/packages/lib/shared/package.json
@@ -21,7 +21,7 @@
     "typescript": "^4.4.2"
   },
   "scripts": {
-    "build": "yarn tsc --declaration",
+    "build": "yarn tsc --declaration  --declarationMap",
     "test": "echo 'no tests'"
   },
   "files": [

--- a/packages/lib/storage/package.json
+++ b/packages/lib/storage/package.json
@@ -25,7 +25,7 @@
     "typescript": "^4.4.2"
   },
   "scripts": {
-    "build": "yarn tsc --declaration ",
+    "build": "yarn tsc --declaration  --declarationMap",
     "test": "jest --coverage --transformIgnorePatterns 'node_modules/(?!(dm3-lib-\\w*)/)'"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2032,7 +2032,6 @@ __metadata:
     jest: ^29.2.2
     jest-mock-extended: 2.0.4
     prettier: ^2.6.2
-    prisma: ^5.10.1
     redis: ^4.1.0
     socket.io: ^4.5.1
     superagent: ^8.0.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -2168,6 +2168,7 @@ __metadata:
     "@dm3-org/dm3-lib-shared": "workspace:^"
     "@types/data-urls": ^3.0.1
     "@types/jest": ^28.1.1
+    "@types/jsonwebtoken": ^9.0.6
     "@types/libsodium-wrappers": ^0.7.10
     "@types/node": ^16.7.13
     "@types/nodemailer": ^6.4.9
@@ -2175,6 +2176,7 @@ __metadata:
     "@types/whatwg-encoding": ^2.0.0
     ethers: 5.7.2
     jest: ^28.1.1
+    jsonwebtoken: ^9.0.2
     nodemailer: 6.9.7
     ts-jest: ^28.0.4
     ts-json-schema-generator: ^0.98.0
@@ -6902,6 +6904,15 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: e60b153664572116dfea673c5bda7778dbff150498f44f998e34b5886d8afc47f16799280e4b6e241c0472aef1bc36add771c569c68fc5125fc2ae519a3eb9ac
+  languageName: node
+  linkType: hard
+
+"@types/jsonwebtoken@npm:^9.0.6":
+  version: 9.0.6
+  resolution: "@types/jsonwebtoken@npm:9.0.6"
+  dependencies:
+    "@types/node": "*"
+  checksum: a568e7cb1c703bcb015eff8bf5996e276e748d2b39ddc47edf5ddccd1378f5792179c43302a1c803e47a54b0220f9ecaae445ec444d28bf81b88856f899e85b9
   languageName: node
   linkType: hard
 
@@ -20939,6 +20950,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonwebtoken@npm:^9.0.2":
+  version: 9.0.2
+  resolution: "jsonwebtoken@npm:9.0.2"
+  dependencies:
+    jws: ^3.2.2
+    lodash.includes: ^4.3.0
+    lodash.isboolean: ^3.0.3
+    lodash.isinteger: ^4.0.4
+    lodash.isnumber: ^3.0.3
+    lodash.isplainobject: ^4.0.6
+    lodash.isstring: ^4.0.1
+    lodash.once: ^4.0.0
+    ms: ^2.1.1
+    semver: ^7.5.4
+  checksum: fc739a6a8b33f1974f9772dca7f8493ca8df4cc31c5a09dcfdb7cff77447dcf22f4236fb2774ef3fe50df0abeb8e1c6f4c41eba82f500a804ab101e2fbc9d61a
+  languageName: node
+  linkType: hard
+
 "jsprim@npm:^1.2.2":
   version: 1.4.2
   resolution: "jsprim@npm:1.4.2"
@@ -20963,6 +20992,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jwa@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "jwa@npm:1.4.1"
+  dependencies:
+    buffer-equal-constant-time: 1.0.1
+    ecdsa-sig-formatter: 1.0.11
+    safe-buffer: ^5.0.1
+  checksum: ff30ea7c2dcc61f3ed2098d868bf89d43701605090c5b21b5544b512843ec6fd9e028381a4dda466cbcdb885c2d1150f7c62e7168394ee07941b4098e1035e2f
+  languageName: node
+  linkType: hard
+
 "jwa@npm:^2.0.0":
   version: 2.0.0
   resolution: "jwa@npm:2.0.0"
@@ -20971,6 +21011,16 @@ __metadata:
     ecdsa-sig-formatter: 1.0.11
     safe-buffer: ^5.0.1
   checksum: 8f00b71ad5fe94cb55006d0d19202f8f56889109caada2f7eeb63ca81755769ce87f4f48101967f398462e3b8ae4faebfbd5a0269cb755dead5d63c77ba4d2f1
+  languageName: node
+  linkType: hard
+
+"jws@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "jws@npm:3.2.2"
+  dependencies:
+    jwa: ^1.4.1
+    safe-buffer: ^5.0.1
+  checksum: f0213fe5b79344c56cd443428d8f65c16bf842dc8cb8f5aed693e1e91d79c20741663ad6eff07a6d2c433d1831acc9814e8d7bada6a0471fbb91d09ceb2bf5c2
   languageName: node
   linkType: hard
 
@@ -21644,10 +21694,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.includes@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.includes@npm:4.3.0"
+  checksum: 71092c130515a67ab3bd928f57f6018434797c94def7f46aafa417771e455ce3a4834889f4267b17887d7f75297dfabd96231bf704fd2b8c5096dc4a913568b6
+  languageName: node
+  linkType: hard
+
 "lodash.isarguments@npm:^3.1.0":
   version: 3.1.0
   resolution: "lodash.isarguments@npm:3.1.0"
   checksum: ae1526f3eb5c61c77944b101b1f655f846ecbedcb9e6b073526eba6890dc0f13f09f72e11ffbf6540b602caee319af9ac363d6cdd6be41f4ee453436f04f13b5
+  languageName: node
+  linkType: hard
+
+"lodash.isboolean@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "lodash.isboolean@npm:3.0.3"
+  checksum: b70068b4a8b8837912b54052557b21fc4774174e3512ed3c5b94621e5aff5eb6c68089d0a386b7e801d679cd105d2e35417978a5e99071750aa2ed90bffd0250
   languageName: node
   linkType: hard
 
@@ -21665,6 +21729,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.isinteger@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "lodash.isinteger@npm:4.0.4"
+  checksum: 6034821b3fc61a2ffc34e7d5644bb50c5fd8f1c0121c554c21ac271911ee0c0502274852845005f8651d51e199ee2e0cfebfe40aaa49c7fe617f603a8a0b1691
+  languageName: node
+  linkType: hard
+
+"lodash.isnumber@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "lodash.isnumber@npm:3.0.3"
+  checksum: 913784275b565346255e6ae6a6e30b760a0da70abc29f3e1f409081585875105138cda4a429ff02577e1bc0a7ae2a90e0a3079a37f3a04c3d6c5aaa532f4cab2
+  languageName: node
+  linkType: hard
+
+"lodash.isplainobject@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "lodash.isplainobject@npm:4.0.6"
+  checksum: 29c6351f281e0d9a1d58f1a4c8f4400924b4c79f18dfc4613624d7d54784df07efaff97c1ff2659f3e085ecf4fff493300adc4837553104cef2634110b0d5337
+  languageName: node
+  linkType: hard
+
+"lodash.isstring@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "lodash.isstring@npm:4.0.1"
+  checksum: eaac87ae9636848af08021083d796e2eea3d02e80082ab8a9955309569cb3a463ce97fd281d7dc119e402b2e7d8c54a23914b15d2fc7fff56461511dc8937ba0
+  languageName: node
+  linkType: hard
+
 "lodash.memoize@npm:4.x, lodash.memoize@npm:^4.1.2":
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
@@ -21676,6 +21768,13 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash.once@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "lodash.once@npm:4.1.1"
+  checksum: d768fa9f9b4e1dc6453be99b753906f58990e0c45e7b2ca5a3b40a33111e5d17f6edf2f768786e2716af90a8e78f8f91431ab8435f761fef00f9b0c256f6d245
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2251,6 +2251,8 @@ __metadata:
     "@dm3-org/dm3-lib-profile": "workspace:^"
     "@dm3-org/dm3-lib-shared": "workspace:^"
     express: ^4.18.1
+    jest: ^29.7.0
+    ts-jest: ^29.1.2
     typescript: ^4.4.2
   languageName: unknown
   linkType: soft
@@ -20354,7 +20356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.7.0":
+"jest-util@npm:^29.0.0, jest-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-util@npm:29.7.0"
   dependencies:
@@ -20556,7 +20558,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^29.2.2":
+"jest@npm:^29.2.2, jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest@npm:29.7.0"
   dependencies:
@@ -29055,6 +29057,39 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: c72e9292709e77ce47ac7813cb24feaa9d01dc983598d29a821f224b5cc190dc7d67e17379cef089095404c00b9d582ee91c727916f9ec289cb1b723df408ae3
+  languageName: node
+  linkType: hard
+
+"ts-jest@npm:^29.1.2":
+  version: 29.1.2
+  resolution: "ts-jest@npm:29.1.2"
+  dependencies:
+    bs-logger: 0.x
+    fast-json-stable-stringify: 2.x
+    jest-util: ^29.0.0
+    json5: ^2.2.3
+    lodash.memoize: 4.x
+    make-error: 1.x
+    semver: ^7.5.3
+    yargs-parser: ^21.0.1
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3 <6"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: a0ce0affc1b716c78c9ab55837829c42cb04b753d174a5c796bb1ddf9f0379fc20647b76fbe30edb30d9b23181908138d6b4c51ef2ae5e187b66635c295cefd5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #779 and #824 

- [x] disable requirement for authentication when sending a message to a delivery service
- [x] disable rpc call forwarding 
- [x] introduce jwt

Still todo:
- Currently I am unable to use the public/private key pairs we already have for the JWTs because I can not figure out the conversion between the expected key formats. Using symmetric approach for now, will [check back later](https://github.com/dm3-org/dm3/issues/909).
- clean up db schema as several fields are not needed anymore

# Summary
- challenge was already signed using the derived keys -> nice
- second signature with wallet is still needed to prove that these keys belong to this wallet
- we now issue jwt instead of a uuid we need to track in database