### PR TITLE
all BSD 2-clause now

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "dm3",
+    "license": "BSD-2-Clause",
     "private": true,
     "workspaces": {
         "packages": [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-backend",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/billboard-client/package.json
+++ b/packages/billboard-client/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-billboard-client",
+  "license": "BSD-2-Clause",
   "version": "1.0.6",
   "private": true,
   "main": "dist/index.js",

--- a/packages/billboard-widget/package.json
+++ b/packages/billboard-widget/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-billboard-widget",
+  "license": "BSD-2-Clause",
   "version": "1.0.6",
   "files": [
     "dist"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-cli",
+  "license": "BSD-2-Clause",
   "version": "0.1.0",
   "scripts": {
     "dm3": "ts-node index.ts",

--- a/packages/delivery-service/package.json
+++ b/packages/delivery-service/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/delivery-service",
+  "license": "BSD-2-Clause",
   "version": "1.0.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dm3-org/dm3-integration-tests",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
-  "license": "MIT",
   "dependencies": {
     "@dm3-org/dm3-lib-delivery": "workspace:^",
     "@dm3-org/dm3-lib-messaging": "workspace:^",

--- a/packages/lib/billboard-api/package.json
+++ b/packages/lib/billboard-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dm3-org/dm3-lib-billboard-client-api",
+  "license": "BSD-2-Clause",
   "version": "1.0.6",
-  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/lib/crypto/package.json
+++ b/packages/lib/crypto/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-lib-crypto",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
   "main": "dist/index.js",
   "module": "dist-backend/index.js",

--- a/packages/lib/delivery-api/package.json
+++ b/packages/lib/delivery-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dm3-org/dm3-lib-delivery-api",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
-  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/lib/delivery/package.json
+++ b/packages/lib/delivery/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dm3-org/dm3-lib-delivery",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
-  "license": "MIT",
   "main": "dist/index.js",
   "module": "dist-backend/index.js",
   "types": "dist/index.d.ts",

--- a/packages/lib/messaging/package.json
+++ b/packages/lib/messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dm3-org/dm3-lib-messaging",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
-  "license": "MIT",
   "main": "dist/index.js",
   "module": "dist-backend/index.js",
   "types": "dist/index.d.ts",

--- a/packages/lib/profile/package.json
+++ b/packages/lib/profile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dm3-org/dm3-lib-profile",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
-  "license": "MIT",
   "main": "dist/index.js",
   "module": "dist-backend/index.js",
   "types": "dist/index.d.ts",

--- a/packages/lib/server-side/package.json
+++ b/packages/lib/server-side/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-lib-server-side",
+  "license": "BSD-2-Clause",
   "version": "0.0.1-alpha1",
   "main": "dist/index.js",
   "module": "dist-backend/index.js",

--- a/packages/lib/shared/package.json
+++ b/packages/lib/shared/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-lib-shared",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
   "main": "dist/index.js",
   "module": "dist-backend/index.js",

--- a/packages/lib/storage/package.json
+++ b/packages/lib/storage/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-lib-storage",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
   "main": "dist/index.js",
   "module": "dist-backend/index.js",

--- a/packages/messenger-demo/package.json
+++ b/packages/messenger-demo/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-messenger-demo",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
   "dependencies": {
     "@dm3-org/dm3-messenger-widget": "workspace:^",

--- a/packages/messenger-web/package.json
+++ b/packages/messenger-web/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-messenger-web",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
   "dependencies": {
     "@dm3-org/dm3-messenger-widget": "workspace:^",

--- a/packages/messenger-widget/package.json
+++ b/packages/messenger-widget/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-messenger-widget",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
   "main": "./lib/cjs/widget.js",
   "module": "./lib/esm/widget.js",

--- a/packages/next-messenger-demo/package.json
+++ b/packages/next-messenger-demo/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/next-messenger-demo",
+  "license": "BSD-2-Clause",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/packages/offchain-resolver/package.json
+++ b/packages/offchain-resolver/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-offchain-resolver",
+  "license": "BSD-2-Clause",
   "version": "1.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/toplevel-alias/package.json
+++ b/packages/toplevel-alias/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@dm3-org/dm3-toplevel-alias",
+  "license": "BSD-2-Clause",
   "version": "0.1.0",
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.0",


### PR DESCRIPTION
this gets rid of the ever-present `warning package.json: No license field`