### PR TITLE
set node docker container to 3.18

### DIFF
--- a/docker/DockerfileBase
+++ b/docker/DockerfileBase
@@ -1,5 +1,5 @@
 ## Create a base image that contains some common tools and all libraries
-FROM --platform=linux/amd64 node:22-alpine-3.18 as base
+FROM --platform=linux/amd64 node:22-alpine3.18 as base
 RUN apk add --update bash gawk \
    && rm -rf /var/cache/apk/*
 

--- a/docker/DockerfileBase
+++ b/docker/DockerfileBase
@@ -1,5 +1,5 @@
 ## Create a base image that contains some common tools and all libraries
-FROM --platform=linux/amd64 node:22-alpine as base
+FROM --platform=linux/amd64 node:22-alpine-3.18 as base
 RUN apk add --update bash gawk \
    && rm -rf /var/cache/apk/*
 

--- a/docker/DockerfileBuild
+++ b/docker/DockerfileBuild
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:22-alpine as build
+FROM --platform=linux/amd64 node:22-alpine3.18 as build
 WORKDIR /build
 COPY . .
 # we need coreutils for proper ls command


### PR DESCRIPTION
node:22-alpine-3.19 was released yesterday and
causes our builds to fail. Reverting to last
working version 3.18.