### PR TITLE
Update metrics format again

### DIFF
--- a/packages/delivery-service/src/metrics.ts
+++ b/packages/delivery-service/src/metrics.ts
@@ -34,10 +34,10 @@ export default (
         const csvData = [headers.join(','), ...csvRows].join('\n');
 
         res.setHeader('Content-Type', 'text/csv');
-        res.setHeader(
-            'Content-Disposition',
-            'attachment; filename=metrics.csv',
-        );
+        // res.setHeader(
+        //     'Content-Disposition',
+        //     'attachment; filename=metrics.csv',
+        // );
         return res.status(200).send(csvData);
     });
 

--- a/packages/delivery-service/src/metrics.ts
+++ b/packages/delivery-service/src/metrics.ts
@@ -1,6 +1,8 @@
 import { DeliveryServiceProperties } from '@dm3-org/dm3-lib-delivery';
 import express from 'express';
 import { IDatabase } from './persistence/getDatabase';
+import { IntervalMetric } from './persistence/metrics/metricTypes';
+
 /**
  * The metrics endpoint returns the metrics of the delivery service.
  * These can include the number of messages received, the cumulative size of messages received, etc.,
@@ -13,9 +15,30 @@ export default (
 ) => {
     const router = express.Router();
     router.get('', async (req, res) => {
-        const metrics = await db.getMetrics(deliveryServiceProperties);
+        const metrics: IntervalMetric[] = await db.getMetrics(
+            deliveryServiceProperties,
+        );
 
-        return res.status(200).send(JSON.stringify(metrics));
+        if (metrics.length === 0) {
+            return res.status(204).send('No metrics data available');
+        }
+
+        // Convert metrics to CSV format
+        const headers = Object.keys(metrics[0]);
+        const csvRows = metrics.map((metric) =>
+            headers
+                .map((header) => metric[header as keyof IntervalMetric])
+                .join(','),
+        );
+
+        const csvData = [headers.join(','), ...csvRows].join('\n');
+
+        res.setHeader('Content-Type', 'text/csv');
+        res.setHeader(
+            'Content-Disposition',
+            'attachment; filename=metrics.csv',
+        );
+        return res.status(200).send(csvData);
     });
 
     return router;

--- a/packages/delivery-service/src/persistence/metrics/getMetrics.test.ts
+++ b/packages/delivery-service/src/persistence/metrics/getMetrics.test.ts
@@ -51,8 +51,8 @@ describe('getMetrics', () => {
         );
         expect(result).toHaveLength(24);
         expect(result[0]).toEqual({
-            timestamp_start: 1680307200,
-            duration_seconds: 3600,
+            timestampStart: 1680307200,
+            durationSeconds: 3600,
             messageCount: 10,
             messageSizeBytes: 1000,
             notificationCount: 5,
@@ -86,8 +86,8 @@ describe('getMetrics', () => {
 
         expect(result).toHaveLength(1);
         expect(result[0]).toEqual({
-            timestamp_start: 1680307200,
-            duration_seconds: 3600,
+            timestampStart: 1680307200,
+            durationSeconds: 3600,
             messageCount: 10,
             messageSizeBytes: 0,
             notificationCount: 5,
@@ -107,11 +107,11 @@ describe('getMetrics', () => {
         const result = await getMetricsFunction(mockDeliveryServiceProperties);
 
         expect(result).toHaveLength(1);
-        expect(result[0].timestamp_start).toBe(currentTimestamp - 3600); // 2023-04-01T11:00:00.000Z
+        expect(result[0].timestampStart).toBe(currentTimestamp - 3600); // 2023-04-01T11:00:00.000Z
         expect(
             result.every(
                 (metric) =>
-                    metric.timestamp_start !==
+                    metric.timestampStart !==
                     Math.floor(mockDate.getTime() / 1000),
             ),
         ).toBe(true);

--- a/packages/delivery-service/src/persistence/metrics/getMetrics.ts
+++ b/packages/delivery-service/src/persistence/metrics/getMetrics.ts
@@ -43,8 +43,8 @@ export function getMetrics(
             );
 
             metrics.push({
-                timestamp_start: timestamp,
-                duration_seconds:
+                timestampStart: timestamp,
+                durationSeconds:
                     deliveryServiceProperties.metricsCollectionIntervalInSeconds,
                 messageCount: parseInt(messageCount || '0', 10),
                 messageSizeBytes: parseInt(messageSizeBytes || '0', 10),

--- a/packages/delivery-service/src/persistence/metrics/metricTypes.ts
+++ b/packages/delivery-service/src/persistence/metrics/metricTypes.ts
@@ -1,6 +1,6 @@
 export type IntervalMetric = {
-    timestamp_start: number;
-    duration_seconds: number;
+    timestampStart: number;
+    durationSeconds: number;
     messageCount: number;
     messageSizeBytes: number;
     notificationCount: number;


### PR DESCRIPTION
because csv is better suited to communicate several separate measurements with dedicated timestamps